### PR TITLE
Replace commit-back versioning with build-time version injection

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -25,12 +25,12 @@ on:
         type: string
         required: false
       versionMode:
-        description: "none | npm | csproj"
+        description: "How to inject version at build time: none | npm | csproj"
         type: string
         required: false
         default: "none"
       versionFiles:
-        description: "Newline-separated file paths to update"
+        description: "Newline-separated file paths to update (used by npm mode to set version in package.json files before build)"
         type: string
         required: false
       buildArgs:
@@ -46,16 +46,6 @@ on:
         description: "Optional shell commands to run before docker build (e.g. fetch artifacts)"
         type: string
         required: false
-      gitUserName:
-        description: "Git username for commits."
-        type: string
-        required: false
-        default: "github-actions[bot]"
-      gitUserEmail:
-        description: "Git user email for commits."
-        type: string
-        required: false
-        default: "41898282+github-actions[bot]@users.noreply.github.com"
 
     secrets:
       DOCKERHUB_USERNAME:
@@ -69,8 +59,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Determine Push Condition
         id: push_condition
@@ -106,8 +94,8 @@ jobs:
       - name: Determine version from tag
         id: version
         run: |
-          if [[ -n "${{ inputs.tagName }}" ]]; then
-            TAG="${{ inputs.tagName }}"
+          if [[ -n "$INPUT_TAG_NAME" ]]; then
+            TAG="$INPUT_TAG_NAME"
           elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
           else
@@ -121,81 +109,44 @@ jobs:
             exit 0
           fi
 
+          # Strip leading 'v' to get numeric semver only
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "TAG=$TAG" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tagName }}
 
-      - name: Update app version files
-        id: update_versions
-        if: steps.push_condition.outputs.push == 'true' && steps.version.outputs.tag != '' && inputs.versionMode != 'none' && inputs.versionFiles != ''
+      - name: Inject version into package.json files (npm)
+        if: inputs.versionMode == 'npm' && steps.version.outputs.version != '' && inputs.versionFiles != ''
         run: |
-          echo "Updating version to: $VERSION"
-          mapfile -t FILES <<< "${{ inputs.versionFiles }}"
-
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Setting npm version to: $VERSION"
+          mapfile -t FILES <<< "$INPUT_VERSION_FILES"
           for f in "${FILES[@]}"; do
             if [[ ! -f "$f" ]]; then
-              echo "Version file not found: $f"
+              echo "::error::Version file not found: $f"
               exit 1
             fi
+            dir=$(dirname "$f")
+            pushd "$dir" > /dev/null
+            npm version "$VERSION" --no-git-tag-version --allow-same-version
+            popd > /dev/null
+            echo "Updated $f to version $VERSION"
           done
+        env:
+          INPUT_VERSION_FILES: ${{ inputs.versionFiles }}
 
-          if [[ "${{ inputs.versionMode }}" == "npm" ]]; then
-            for f in "${FILES[@]}"; do
-              node -e "
-                const fs = require('fs');
-                const p = '$f';
-                const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
-                pkg.version = process.env.VERSION;
-                fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
-              "
-            done
-          elif [[ "${{ inputs.versionMode }}" == "csproj" ]]; then
-            for f in "${FILES[@]}"; do
-              perl -0777 -i -pe "s|<Version>.*?</Version>|<Version>$VERSION</Version>|g" "$f"
-            done
-          else
-            echo "Unknown versionMode: ${{ inputs.versionMode }}"
-            exit 1
-          fi
-
-          if git diff --quiet; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "No version file changes detected."
-          else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            echo "Version file changes detected:"
-            git diff
-          fi
-
-      - name: Commit version bump
-        if: steps.push_condition.outputs.push == 'true' && steps.update_versions.conclusion == 'success' && steps.update_versions.outputs.has_changes == 'true'
+      - name: Prepare build args for .NET version (csproj)
+        id: version_build_args
+        if: inputs.versionMode == 'csproj' && steps.version.outputs.version != ''
         run: |
-          git config user.name "${{ inputs.gitUserName }}"
-          git config user.email "${{ inputs.gitUserEmail }}"
-
-          mapfile -t FILES <<< "${{ inputs.versionFiles }}"
-          git add "${FILES[@]}"
-          git commit -m "chore: set version to $VERSION"
-
-      - name: Push version bump commit to main branch
-        if: steps.push_condition.outputs.push == 'true' && steps.update_versions.conclusion == 'success' && steps.update_versions.outputs.has_changes == 'true'
-        run: |
-          git push origin HEAD:main
-
-      - name: Force-move tag to include version bump commit
-        if: steps.push_condition.outputs.push == 'true' && steps.update_versions.conclusion == 'success' && steps.update_versions.outputs.has_changes == 'true'
-        run: |
-          git tag -f "$TAG"
-          git push origin -f "refs/tags/$TAG"
-
-      - name: Re-checkout moved tag (so build uses updated code)
-        if: steps.push_condition.outputs.push == 'true' && steps.update_versions.conclusion == 'success' && steps.update_versions.outputs.has_changes == 'true'
-        run: |
-          git fetch --tags --force
-          git checkout -f "tags/$TAG"
-          git rev-parse HEAD
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Injecting .NET version as build args: $VERSION"
+          {
+            echo "args<<EOF"
+            echo "VERSION=$VERSION"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         if: inputs.enableQemu
@@ -230,7 +181,7 @@ jobs:
         id: target_tags
         run: |
           TARGET_TAGS=""
-          readarray -t TAG_ARRAY <<< "${{ steps.meta.outputs.tags }}"
+          mapfile -t TAG_ARRAY <<< "${{ steps.meta.outputs.tags }}"
 
           for full_tag in "${TAG_ARRAY[@]}"; do
             # Extract just the tag part after the colon
@@ -246,7 +197,7 @@ jobs:
 
             new_tag="${image_name}:${tag_part}-${{ inputs.additionalTarget }}"
 
-            if [[ ! -z "$TARGET_TAGS" ]]; then
+            if [[ -n "$TARGET_TAGS" ]]; then
               TARGET_TAGS="${TARGET_TAGS},"
             fi
             TARGET_TAGS="${TARGET_TAGS}${new_tag}"
@@ -254,6 +205,23 @@ jobs:
 
           echo "tags=${TARGET_TAGS}" >> $GITHUB_OUTPUT
           echo "Generated additional target tags: ${TARGET_TAGS}"
+
+      - name: Combine build args
+        id: combined_build_args
+        run: |
+          {
+            echo "args<<EOF"
+            if [[ -n "$USER_ARGS" ]]; then
+              echo "$USER_ARGS"
+            fi
+            if [[ -n "$VERSION_ARGS" ]]; then
+              echo "$VERSION_ARGS"
+            fi
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+        env:
+          USER_ARGS: ${{ inputs.buildArgs }}
+          VERSION_ARGS: ${{ steps.version_build_args.outputs.args }}
 
       - name: Build and push default stage
         uses: docker/build-push-action@v6
@@ -264,7 +232,7 @@ jobs:
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.buildArgs }}
+          build-args: ${{ steps.combined_build_args.outputs.args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -279,7 +247,7 @@ jobs:
           pull: true
           tags: ${{ steps.target_tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.buildArgs }}
+          build-args: ${{ steps.combined_build_args.outputs.args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,12 @@ The action checks out the current branch, runs `header.py` to add missing header
 | `tagName` |  | Explicit tag override. When omitted, tags are inferred from semver, branches, or tags. |
 | `dockerfilePath` |  | Path to the Dockerfile (`./Dockerfile` by default). |
 | `additionalTarget` |  | Optional extra build stage to publish (tags will be suffixed with `-<target>`). |
-| `push` |  | Set to `false` to force a build-only run even outside PRs. Defaults to `true` on non‑PR events. |
+| `push` |  | Set to `false` to force a build-only run even outside PRs. Defaults to `true` on non-PR events. |
+| `versionMode` |  | How to inject version at build time: `none` (default), `npm`, or `csproj`. |
+| `versionFiles` |  | Newline-separated file paths to update (used by `npm` mode to set version in `package.json` files before build). |
+| `buildArgs` |  | Optional Docker build args (newline-separated `key=value`). |
+| `enableQemu` |  | Set to `true` to enable QEMU for multi-arch builds. Defaults to `false`. |
+| `preBuildCommands` |  | Optional shell commands to run before the Docker build (e.g., fetch artifacts). |
 
 #### Required Secrets
 


### PR DESCRIPTION
Replace commit-back versioning with build-time version injection in the Docker build workflow, and clean up residual issues.                                                                                                                                                                  
   
## Changes                                                                                                                                                                                                                                                                                       
                  
### Build-time versioning

  The workflow previously updated version files (package.json, .csproj), committed the changes, pushed to main, force-moved the tag, and re-checked out — all before building the image. This created noisy commits, required write access to main, and introduced a race condition if multiple releases ran concurrently.

  Now, version injection happens entirely on the runner during the build:
  - npm/Angular: npm version <semver> --no-git-tag-version updates package.json in the build context before docker build
  - .NET/csproj: A VERSION build arg is passed to docker build-push-action, which Dockerfiles consume via ARG VERSION and dotnet publish /p:Version=$VERSION

  In both cases, the v prefix is stripped from git tags so only numeric semver (e.g., 1.2.3) is used.                                                                                                                                                                                           
   
### Removed                                                                                                                                                                                                                                                                                       
                  
  - gitUserName and gitUserEmail inputs (no longer committing)
  - Steps: "Update app version files", "Commit version bump", "Push version bump commit to main branch", "Force-move tag to include version bump commit", "Re-checkout moved tag"

### Cleanup

  - Script injection hardening: tagName and versionFiles inputs are now passed through env: blocks instead of direct ${{ }} interpolation in shell scripts
  - Shallow clone: Removed fetch-depth: 0 (full clone was only needed for the commit-back flow)
  - Style consistency: readarray → mapfile, ! -z → -n
  - README: Updated the inputs table to document all current inputs (versionMode, versionFiles, buildArgs, enableQemu, preBuildCommands)

## Migration notes

  - Callers using versionMode: npm — no changes needed; versionFiles still works, but files are updated on the runner only (never committed)
  - Callers using versionMode: csproj — Dockerfiles must accept and use the VERSION build arg:
  ARG VERSION
  RUN dotnet publish -c Release /p:Version=${VERSION} /p:AssemblyVersion=${VERSION}
  - Callers passing gitUserName or gitUserEmail — remove these inputs (they are no longer accepted)