### PR TITLE
Use multi-arch build by default

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -37,11 +37,11 @@ on:
         description: "Optional docker build args (newline-separated: key=value)"
         type: string
         required: false
-      enableQemu:
-        description: "Set to true to enable QEMU for multi-arch builds"
-        type: boolean
+      platforms:
+        description: "Comma-separated list of target platforms (e.g., linux/amd64,linux/arm64)"
+        type: string
         required: false
-        default: false
+        default: "linux/amd64,linux/arm64"
       preBuildCommands:
         description: "Optional shell commands to run before docker build (e.g. fetch artifacts)"
         type: string
@@ -149,22 +149,22 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        if: inputs.enableQemu
-        uses: docker/setup-qemu-action@v3
+        if: contains(inputs.platforms, 'arm64')
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
         if: steps.push_condition.outputs.push == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Docker Meta for primary image
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ inputs.imageName }}
           tags: |
@@ -224,10 +224,11 @@ jobs:
           VERSION_ARGS: ${{ steps.version_build_args.outputs.args }}
 
       - name: Build and push default stage
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ inputs.dockerfilePath }}
+          platforms: ${{ inputs.platforms }}
           push: ${{ steps.push_condition.outputs.push }}
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -238,11 +239,12 @@ jobs:
 
       - name: Build and push additional target
         if: inputs.additionalTarget != ''
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ inputs.dockerfilePath }}
           target: ${{ inputs.additionalTarget }}
+          platforms: ${{ inputs.platforms }}
           push: ${{ steps.push_condition.outputs.push }}
           pull: true
           tags: ${{ steps.target_tags.outputs.tags }}
@@ -250,4 +252,3 @@ jobs:
           build-args: ${{ steps.combined_build_args.outputs.args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-


### PR DESCRIPTION
## Summary
- Add multi-architecture Docker builds (amd64 + arm64) by default
- Replace enableQemu input with platforms input for explicit platform control
- QEMU setup now auto-triggers when arm64 is in the platform list
- Bump all Docker GitHub Actions to latest major versions (setup-qemu v4, setup-buildx v4, login v4, metadata v6, build-push v7)

## Breaking Changes

- The `enableQemu` input has been removed. Callers using `enableQemu: true` will see it silently ignored — no build failures since multi-arch is now the default behavior anyway.
- To build for a single architecture only, pass `platforms: "linux/amd64"`