### PR TITLE
Adds appsettings updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The action:
 | `helm_repo_token` |  | Optional repository token override. |
 | `git_user_name` |  | Commit author name (`github-actions[bot]`). |
 | `git_user_email` |  | Commit author email (`41898282+github-actions[bot]@users.noreply.github.com`). |
+| `settings_file` |  | Path in the calling repo to the app settings file (e.g. `Player.Api/appsettings.json`). When set, enables the settings-sync phase. Omit to disable. |
+| `settings_file_kind` |  | One of `dotnet-appsettings` or `angular-settings`. Required when `settings_file` is set. |
 
 #### Outputs
 
@@ -43,6 +45,20 @@ The action:
 - `chart_modified` – `true` when an update was required
 - `branch_name` – suggested feature branch for the PR
 - `has_changes` – `true` when any files were modified
+- `settings_changed` – `true` when settings were added or removed between the previous and new release tags
+- `settings_added` – JSON object mapping added flattened setting keys to their leaf type
+- `settings_removed` – JSON array of removed flattened setting keys
+- `previous_release_tag` – resolved previous release tag (empty when no prior tag exists)
+
+#### Settings sync (optional)
+
+When `settings_file` and `settings_file_kind` are set, the action additionally diffs the settings file between the previous and new release tags and propagates added/removed leaf keys:
+
+- Updates the `env:` block (for `dotnet-appsettings`) or `settings:` / `settingsYaml:` blocks (for `angular-settings`) in the child chart's `values.yaml`.
+- Mirrors the same changes under the parent chart's subkey in the parent `values.yaml` when `parent_chart_file` is set and the subkey's block already exists. The subkey is derived from the chart folder name.
+- Appends a "Settings changes to review" section to the helm-charts PR body listing added/removed keys so a human can update the hand-curated chart README.
+
+New keys are inserted with blank placeholders by JSON type (`""`, `false`, `0`). No README edits are made automatically. Re-running the action for the same release is a no-op.
 
 #### Example Usage
 

--- a/actions/update-helm-chart/action.yaml
+++ b/actions/update-helm-chart/action.yaml
@@ -41,6 +41,14 @@ inputs:
     description: "Git user email for commits."
     required: false
     default: "41898282+github-actions[bot]@users.noreply.github.com"
+  settings_file:
+    description: "Path in the calling repo to the app settings file (e.g. Player.Api/appsettings.json). When set, enables the settings-sync phase."
+    required: false
+    default: ""
+  settings_file_kind:
+    description: "Strategy for parsing settings_file. One of: dotnet-appsettings, angular-settings. Required when settings_file is set."
+    required: false
+    default: ""
 outputs:
   new_app_version:
     description: "Normalized application version extracted from the release tag."
@@ -63,6 +71,18 @@ outputs:
   has_changes:
     description: "True when any chart files were updated."
     value: ${{ steps.update.outputs.has_changes }}
+  settings_changed:
+    description: "True when settings were added or removed between the previous release tag and this one."
+    value: ${{ steps.update.outputs.settings_changed }}
+  settings_added:
+    description: "JSON object mapping added flattened setting keys to their leaf type."
+    value: ${{ steps.update.outputs.settings_added }}
+  settings_removed:
+    description: "JSON array of removed flattened setting keys."
+    value: ${{ steps.update.outputs.settings_removed }}
+  previous_release_tag:
+    description: "Resolved previous release tag (empty when no prior tag exists)."
+    value: ${{ steps.update.outputs.previous_release_tag }}
 
 runs:
   using: "composite"
@@ -110,11 +130,13 @@ runs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install pyyaml
+        python3 -m pip install pyyaml "ruamel.yaml>=0.18,<1"
       shell: bash
 
     - name: Update Helm chart metadata
       id: update
+      env:
+        SOURCE_REPO: ${{ github.repository }}
       run: |
         python3 "${{ github.action_path }}/update_helm_chart.py" \
           --helm-repo-dir "helm-charts" \
@@ -122,8 +144,20 @@ runs:
           --parent-chart-file "${{ inputs.parent_chart_file }}" \
           --release-tag "${{ inputs.release_tag }}" \
           --app-name "${{ inputs.app_name }}" \
-          --github-output "$GITHUB_OUTPUT"
+          --github-output "$GITHUB_OUTPUT" \
+          --settings-file "${{ inputs.settings_file }}" \
+          --settings-file-kind "${{ inputs.settings_file_kind }}" \
+          --source-repo "$SOURCE_REPO" \
+          --app-repo-dir "$GITHUB_WORKSPACE"
       shell: bash
+
+    - name: Derive README path
+      if: inputs.parent_chart_file != ''
+      id: readme
+      shell: bash
+      env:
+        PCF: ${{ inputs.parent_chart_file }}
+      run: echo "path=$(dirname "$PCF")/README.md" >> "$GITHUB_OUTPUT"
 
     - name: Create feature branch
       if: steps.update.outputs.has_changes == 'true'
@@ -160,8 +194,25 @@ runs:
         APP_NAME: ${{ inputs.app_name }}
         APP_VERSION: ${{ steps.update.outputs.new_app_version }}
         RELEASE_TYPE: ${{ steps.update.outputs.release_type }}
+        SOURCE_REPO: ${{ github.repository }}
+        SETTINGS_CHANGED: ${{ steps.update.outputs.settings_changed }}
+        SETTINGS_ADDED: ${{ steps.update.outputs.settings_added }}
+        SETTINGS_REMOVED: ${{ steps.update.outputs.settings_removed }}
+        README_PATH: ${{ steps.readme.outputs.path }}
       run: |
-        PR_BODY="Automated update for ${APP_NAME} to version ${APP_VERSION}."
+        RELEASE_URL="https://github.com/${SOURCE_REPO}/releases/tag/${APP_VERSION}"
+        PR_BODY="Automated update for ${APP_NAME} to version [${APP_VERSION}](${RELEASE_URL})."
+        if [ "${SETTINGS_CHANGED}" = "true" ]; then
+          SECTION=$(python3 "${{ github.action_path }}/render_pr_section.py" \
+            --source-repo "${SOURCE_REPO}" \
+            --release-tag "${APP_VERSION}" \
+            --readme-path "${README_PATH}" \
+            --added "${SETTINGS_ADDED:-{\}}" \
+            --removed "${SETTINGS_REMOVED:-[]}")
+          if [ -n "$SECTION" ]; then
+            PR_BODY=$(printf '%s\n\n%s\n' "${PR_BODY}" "${SECTION}")
+          fi
+        fi
         if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
           echo "Pull request already exists for branch ${BRANCH}. Skipping creation."
         else

--- a/actions/update-helm-chart/render_pr_section.py
+++ b/actions/update-helm-chart/render_pr_section.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""CLI wrapper to render the PR-body 'Settings changes to review' section."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from settings_sync.flatten import LeafType
+from settings_sync.pr_body import render_settings_section
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-repo", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--readme-path", default="")
+    parser.add_argument("--added", default="{}")
+    parser.add_argument("--removed", default="[]")
+    args = parser.parse_args()
+
+    added_raw = json.loads(args.added) if args.added.strip() else {}
+    removed = json.loads(args.removed) if args.removed.strip() else []
+
+    added: dict[str, LeafType] = {
+        k: LeafType(v) for k, v in added_raw.items()
+    }
+
+    section = render_settings_section(
+        source_repo=args.source_repo,
+        release_tag=args.release_tag,
+        readme_path=args.readme_path or None,
+        added=added,
+        removed=removed,
+    )
+    if section:
+        print(section)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/actions/update-helm-chart/requirements-dev.txt
+++ b/actions/update-helm-chart/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest>=8,<9
+pyyaml>=6
+ruamel.yaml>=0.18,<1

--- a/actions/update-helm-chart/settings_sync/__init__.py
+++ b/actions/update-helm-chart/settings_sync/__init__.py
@@ -1,0 +1,5 @@
+"""Settings-sync phase for the update-helm-chart composite action."""
+
+from .runner import RunResult, SettingsSyncError, run
+
+__all__ = ["RunResult", "SettingsSyncError", "run"]

--- a/actions/update-helm-chart/settings_sync/diff.py
+++ b/actions/update-helm-chart/settings_sync/diff.py
@@ -1,0 +1,26 @@
+"""Compute added and removed leaf paths between two flattened maps.
+
+Modifications (same path, different LeafType) are intentionally ignored:
+values.yaml uses blank placeholders, so a type change in the source doesn't
+affect the chart.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .flatten import LeafType
+
+
+@dataclass(frozen=True)
+class Diff:
+    added: Dict[str, LeafType] = field(default_factory=dict)
+    removed: List[str] = field(default_factory=list)
+
+
+def compute_diff(
+    prev: Dict[str, LeafType], new: Dict[str, LeafType]
+) -> Diff:
+    added = {k: v for k, v in new.items() if k not in prev}
+    removed = sorted(k for k in prev.keys() if k not in new)
+    return Diff(added=added, removed=removed)

--- a/actions/update-helm-chart/settings_sync/flatten.py
+++ b/actions/update-helm-chart/settings_sync/flatten.py
@@ -1,0 +1,87 @@
+"""Flatten a parsed JSON object to a leaf-path -> type map.
+
+Two strategies:
+  - flatten_dotnet: emits ASP.NET Core env-var style keys (`Section__Key`,
+    `Array__0`). Skips containers that end up empty after JSONC comments are
+    stripped upstream.
+  - flatten_angular: emits JSON Pointer paths (`/Section/key`, `/Array/0`).
+    Used for strict-JSON Angular settings files. Same empty-container skip.
+
+Only scalar-array elements are expanded, and only element 0 is emitted as a
+placeholder (matching existing values.yaml convention). Object arrays and
+deeper array shapes beyond the first scalar element are not flattened further.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict
+
+
+class LeafType(str, Enum):
+    STRING = "string"
+    BOOL = "bool"
+    NUMBER = "number"
+
+
+def _leaf_type(value: Any) -> LeafType | None:
+    if isinstance(value, bool):
+        return LeafType.BOOL
+    if isinstance(value, (int, float)):
+        return LeafType.NUMBER
+    if isinstance(value, str):
+        return LeafType.STRING
+    return None
+
+
+def _is_scalar(value: Any) -> bool:
+    return _leaf_type(value) is not None
+
+
+def flatten_dotnet(data: Any) -> Dict[str, LeafType]:
+    result: Dict[str, LeafType] = {}
+    _walk_dotnet(data, [], result)
+    return result
+
+
+def _walk_dotnet(node: Any, path: list[str], out: Dict[str, LeafType]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            _walk_dotnet(value, path + [str(key)], out)
+        return
+    if isinstance(node, list):
+        if not node:
+            return
+        first = node[0]
+        if _is_scalar(first):
+            key = "__".join(path + ["0"])
+            out[key] = _leaf_type(first)  # type: ignore[assignment]
+        return
+    lt = _leaf_type(node)
+    if lt is None:
+        return
+    out["__".join(path)] = lt
+
+
+def flatten_angular(data: Any) -> Dict[str, LeafType]:
+    result: Dict[str, LeafType] = {}
+    _walk_angular(data, [], result)
+    return result
+
+
+def _walk_angular(node: Any, path: list[str], out: Dict[str, LeafType]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            _walk_angular(value, path + [str(key)], out)
+        return
+    if isinstance(node, list):
+        if not node:
+            return
+        first = node[0]
+        if _is_scalar(first):
+            key = "/" + "/".join(path + ["0"])
+            out[key] = _leaf_type(first)  # type: ignore[assignment]
+        return
+    lt = _leaf_type(node)
+    if lt is None:
+        return
+    out["/" + "/".join(path)] = lt

--- a/actions/update-helm-chart/settings_sync/git_io.py
+++ b/actions/update-helm-chart/settings_sync/git_io.py
@@ -1,0 +1,48 @@
+"""Thin wrapper around `git` subprocess calls. Mockable in tests."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+
+def list_tags(repo_dir: Path) -> List[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), "tag", "--list", "--sort=-v:refname"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def previous_tag(repo_dir: Path, target_tag: str) -> Optional[str]:
+    """Return the tag immediately preceding `target_tag` in version order.
+
+    None when target is not in the tag list or is the oldest tag.
+    """
+    tags = list_tags(repo_dir)
+    try:
+        idx = tags.index(target_tag)
+    except ValueError:
+        return None
+    if idx + 1 >= len(tags):
+        return None
+    return tags[idx + 1]
+
+
+def show_file_at_ref(
+    repo_dir: Path, ref: str, file_path: str
+) -> Optional[str]:
+    """Return the content of `file_path` at `ref`, or None if not present."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), "show", f"{ref}:{file_path}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout

--- a/actions/update-helm-chart/settings_sync/jsonc.py
+++ b/actions/update-helm-chart/settings_sync/jsonc.py
@@ -1,0 +1,53 @@
+"""Strip // line comments and /* */ block comments from JSONC input.
+
+Preserves // and /* inside string literals. Leaves whitespace/newlines intact
+so byte offsets remain close to the original when useful for error reporting.
+"""
+from __future__ import annotations
+
+
+def strip_jsonc_comments(src: str) -> str:
+    out: list[str] = []
+    i = 0
+    n = len(src)
+    in_string = False
+    escape = False
+
+    while i < n:
+        ch = src[i]
+
+        if in_string:
+            out.append(ch)
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+
+        if ch == "/" and i + 1 < n and src[i + 1] == "/":
+            # line comment: skip to end of line, preserve the newline
+            i += 2
+            while i < n and src[i] != "\n":
+                i += 1
+            continue
+
+        if ch == "/" and i + 1 < n and src[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (src[i] == "*" and src[i + 1] == "/"):
+                i += 1
+            i = min(n, i + 2)
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)

--- a/actions/update-helm-chart/settings_sync/patch_angular.py
+++ b/actions/update-helm-chart/settings_sync/patch_angular.py
@@ -1,0 +1,288 @@
+"""Patch `settings:` (stringified JSON) and `settingsYaml:` blocks.
+
+Two emission strategies live here:
+
+* `settings:` (stringified JSON) — parsed, mutated, re-serialized.
+* `settingsYaml:` (commented-out nested YAML) — additions appended as
+  commented-out lines via a post-dump string splice. ruamel's in-map comment
+  APIs don't reliably render end-of-mapping comments for empty/flow-style maps
+  (a common state for this block), so we post-process the dumped text instead.
+
+The post-dump step is applied by the caller via `finalize_dump(text, pending)`.
+Patchers register pending settingsYaml additions on the document using
+`_pending_attr`; the runner calls `finalize_dump` after `yaml.dump(...)` to
+splice them in.
+"""
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Mapping, Optional
+
+from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+
+from .flatten import LeafType
+
+
+_BLANK_BY_TYPE: Mapping[LeafType, object] = {
+    LeafType.STRING: DoubleQuotedScalarString(""),
+    LeafType.BOOL: False,
+    LeafType.NUMBER: 0,
+}
+
+# Attribute name used to stash the list of pending (path, leaf_type) additions
+# so `finalize_dump` can find them on the document. Using a dunder attribute
+# avoids collision with any user YAML key.
+_PENDING_ATTR = "__settings_yaml_pending__"
+
+
+def patch_values(
+    doc: CommentedMap,
+    subkey: Optional[str],
+    added: Dict[str, LeafType],
+    removed: List[str],
+) -> bool:
+    if not added and not removed:
+        return False
+
+    root = _locate_root(doc, subkey)
+    if root is None:
+        return False
+
+    modified = False
+
+    if "settings" in root and isinstance(root["settings"], str):
+        new_json = _patch_settings_json(root["settings"], added, removed)
+        if new_json is not None and new_json != root["settings"]:
+            root["settings"] = new_json
+            modified = True
+
+    if "settingsYaml" in root and added:
+        # Register pending additions on the top-level doc for finalize_dump.
+        pending = getattr(doc, _PENDING_ATTR, None)
+        if pending is None:
+            pending = []
+            setattr(doc, _PENDING_ATTR, pending)
+        pending.append((subkey, dict(added)))
+        modified = True
+
+    return modified
+
+
+def finalize_dump(text: str, doc: CommentedMap) -> str:
+    """Splice any pending settingsYaml additions into the dumped YAML text.
+
+    Must be called by the runner after `yaml.dump(doc, buf)` so that the
+    commented-out lines land in the output file. If `patch_values` was never
+    called with angular kind, this is a no-op.
+    """
+    pending = getattr(doc, _PENDING_ATTR, None)
+    if not pending:
+        return text
+
+    for subkey, added in pending:
+        text = _splice_settings_yaml(text, subkey, added)
+    return text
+
+
+def _locate_root(doc: CommentedMap, subkey: Optional[str]) -> Optional[CommentedMap]:
+    if subkey is None:
+        return doc
+    parent = doc.get(subkey)
+    if not isinstance(parent, CommentedMap):
+        return None
+    return parent
+
+
+def _patch_settings_json(
+    raw: str, added: Dict[str, LeafType], removed: List[str]
+) -> Optional[str]:
+    try:
+        obj = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    for path in removed:
+        _delete_at_pointer(obj, path)
+    for path, leaf_type in added.items():
+        _set_at_pointer(obj, path, _json_blank(leaf_type))
+    return json.dumps(obj)
+
+
+def _json_blank(leaf_type: LeafType) -> object:
+    if leaf_type == LeafType.STRING:
+        return ""
+    if leaf_type == LeafType.BOOL:
+        return False
+    return 0
+
+
+def _pointer_parts(path: str) -> list[str]:
+    if not path.startswith("/"):
+        return []
+    return path[1:].split("/") if path != "/" else []
+
+
+def _set_at_pointer(obj: dict, path: str, value: object) -> None:
+    parts = _pointer_parts(path)
+    if not parts:
+        return
+    cur: dict = obj
+    for part in parts[:-1]:
+        nxt = cur.get(part)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            cur[part] = nxt
+        cur = nxt
+    cur[parts[-1]] = value
+
+
+def _delete_at_pointer(obj: dict, path: str) -> None:
+    parts = _pointer_parts(path)
+    if not parts:
+        return
+    cur: dict = obj
+    for part in parts[:-1]:
+        nxt = cur.get(part)
+        if not isinstance(nxt, dict):
+            return
+        cur = nxt
+    cur.pop(parts[-1], None)
+
+
+def _render_commented_yaml(
+    nested: dict, indent_prefix: str
+) -> list[str]:
+    """Render a nested dict as commented-out YAML lines.
+
+    `indent_prefix` is the whitespace that goes before the `#` on every line
+    (matching the block's child indent). Nested structure is expressed by
+    adding two spaces *after* the `# `, matching the existing UI chart
+    convention, e.g.:
+
+        settingsYaml:
+          # OIDCSettings:
+          #   authority: ""
+    """
+    lines: list[str] = []
+    _render_commented(nested, indent_prefix, "", lines)
+    return lines
+
+
+def _render_commented(
+    obj: dict, outer_indent: str, inner_indent: str, out: list[str]
+) -> None:
+    for key, value in obj.items():
+        if isinstance(value, dict):
+            out.append(f"{outer_indent}# {inner_indent}{key}:")
+            _render_commented(value, outer_indent, inner_indent + "  ", out)
+        else:
+            out.append(
+                f"{outer_indent}# {inner_indent}{key}: {_render_scalar(value)}"
+            )
+
+
+def _render_scalar(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return '""'
+
+
+def _splice_settings_yaml(
+    text: str, subkey: Optional[str], added: Dict[str, LeafType]
+) -> str:
+    """Insert commented-out additions after the settingsYaml: line.
+
+    Finds the `settingsYaml:` key line (scoped under `subkey:` if provided),
+    determines the child indent, and appends commented lines that mirror the
+    nested JSON-pointer structure of `added`.
+    """
+    nested: dict = {}
+    for path, leaf_type in added.items():
+        _set_at_pointer(nested, path, leaf_type)
+
+    lines = text.split("\n")
+
+    # Locate the `settingsYaml:` line. When subkey is given, only consider
+    # indented occurrences (child of the subkey).
+    target_indent: Optional[int] = None
+    if subkey is None:
+        target_indent = 0
+    else:
+        # Find `<subkey>:` at column 0, then look for settingsYaml nested
+        # under it at a deeper indent.
+        subkey_line = None
+        for idx, line in enumerate(lines):
+            if line == f"{subkey}:" or line.startswith(f"{subkey}:"):
+                subkey_line = idx
+                break
+        if subkey_line is None:
+            return text
+        # Child indent: find next non-blank line's leading whitespace.
+        for line in lines[subkey_line + 1 :]:
+            if line.strip():
+                target_indent = len(line) - len(line.lstrip(" "))
+                break
+
+    if target_indent is None:
+        return text
+
+    key_line_idx = _find_settings_yaml_line(lines, target_indent)
+    if key_line_idx is None:
+        return text
+
+    child_indent_str = " " * (target_indent + 2)
+    commented = _render_commented_yaml(
+        _resolve_types(nested), child_indent_str
+    )
+    if not commented:
+        return text
+
+    # If the existing line is `settingsYaml: {}` (or a flow-style variant),
+    # rewrite it to `settingsYaml:` so the appended commented children read
+    # as siblings of other block-style content rather than dangling under an
+    # empty flow map.
+    key_line = lines[key_line_idx]
+    stripped = key_line.strip()
+    if stripped.startswith("settingsYaml:") and stripped != "settingsYaml:":
+        remainder = stripped[len("settingsYaml:") :].strip()
+        if remainder in ("{}", ""):
+            leading = key_line[: len(key_line) - len(key_line.lstrip(" "))]
+            lines[key_line_idx] = f"{leading}settingsYaml:"
+
+    insert_at = key_line_idx + 1
+    new_lines = lines[:insert_at] + commented + lines[insert_at:]
+    return "\n".join(new_lines)
+
+
+def _find_settings_yaml_line(lines: list[str], indent: int) -> Optional[int]:
+    prefix = " " * indent + "settingsYaml:"
+    for idx, line in enumerate(lines):
+        if line == prefix or line.startswith(prefix + " ") or line == prefix.rstrip():
+            return idx
+    return None
+
+
+def _resolve_types(nested: dict) -> dict:
+    """Convert LeafType values at leaves into raw scalar placeholders.
+
+    The splicer's renderer emits "true"/"false"/"0"/'""' based on Python
+    types, so we convert LeafType.BOOL -> False, NUMBER -> 0, STRING -> "".
+    """
+    out: dict = {}
+    for key, value in nested.items():
+        if isinstance(value, dict):
+            out[key] = _resolve_types(value)
+        elif isinstance(value, LeafType):
+            if value == LeafType.BOOL:
+                out[key] = False
+            elif value == LeafType.NUMBER:
+                out[key] = 0
+            else:
+                out[key] = ""
+        else:
+            out[key] = value
+    return out

--- a/actions/update-helm-chart/settings_sync/patch_angular.py
+++ b/actions/update-helm-chart/settings_sync/patch_angular.py
@@ -207,13 +207,14 @@ def _splice_settings_yaml(
     lines = text.split("\n")
 
     # Locate the `settingsYaml:` line. When subkey is given, only consider
-    # indented occurrences (child of the subkey).
+    # occurrences inside the subkey's block (between the subkey line and the
+    # next top-level key) to avoid matching a sibling subkey's settingsYaml.
     target_indent: Optional[int] = None
+    search_start = 0
+    search_end = len(lines)
     if subkey is None:
         target_indent = 0
     else:
-        # Find `<subkey>:` at column 0, then look for settingsYaml nested
-        # under it at a deeper indent.
         subkey_line = None
         for idx, line in enumerate(lines):
             if line == f"{subkey}:" or line.startswith(f"{subkey}:"):
@@ -226,11 +227,23 @@ def _splice_settings_yaml(
             if line.strip():
                 target_indent = len(line) - len(line.lstrip(" "))
                 break
+        # Bound search to the subkey's block: stop at the next line that
+        # starts in column 0 with a non-space character (a sibling top-level
+        # key or list item).
+        search_start = subkey_line + 1
+        search_end = len(lines)
+        for idx in range(search_start, len(lines)):
+            line = lines[idx]
+            if line and not line[0].isspace():
+                search_end = idx
+                break
 
     if target_indent is None:
         return text
 
-    key_line_idx = _find_settings_yaml_line(lines, target_indent)
+    key_line_idx = _find_settings_yaml_line(
+        lines, target_indent, search_start, search_end
+    )
     if key_line_idx is None:
         return text
 
@@ -258,9 +271,16 @@ def _splice_settings_yaml(
     return "\n".join(new_lines)
 
 
-def _find_settings_yaml_line(lines: list[str], indent: int) -> Optional[int]:
+def _find_settings_yaml_line(
+    lines: list[str],
+    indent: int,
+    start: int = 0,
+    end: Optional[int] = None,
+) -> Optional[int]:
     prefix = " " * indent + "settingsYaml:"
-    for idx, line in enumerate(lines):
+    stop = len(lines) if end is None else end
+    for idx in range(start, stop):
+        line = lines[idx]
         if line == prefix or line.startswith(prefix + " ") or line == prefix.rstrip():
             return idx
     return None

--- a/actions/update-helm-chart/settings_sync/patch_dotnet.py
+++ b/actions/update-helm-chart/settings_sync/patch_dotnet.py
@@ -1,0 +1,79 @@
+"""Patch the `env:` block of a values.yaml document.
+
+Operates on a `ruamel.yaml`-loaded document in place. Returns True iff the
+document was modified, so callers can decide whether to write the file back.
+
+Rules (spec: Dotnet-appsettings patcher):
+  * At the root (`subkey=None`) the env: block is created if missing.
+  * Under a subkey (e.g. "player-api" in parent values.yaml) the env: block
+    is NOT created. If missing, we skip — parent values.yaml is hand-curated.
+  * Additions are appended at the end of the env: block.
+  * Blank values: string -> "", bool -> False, number -> 0.
+  * Removals delete the key line in place; preceding comments are left alone.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Mapping, Optional
+
+from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+
+from .flatten import LeafType
+
+
+_BLANK_BY_TYPE: Mapping[LeafType, object] = {
+    LeafType.STRING: DoubleQuotedScalarString(""),
+    LeafType.BOOL: False,
+    LeafType.NUMBER: 0,
+}
+
+
+def patch_values(
+    doc: CommentedMap,
+    subkey: Optional[str],
+    added: Dict[str, LeafType],
+    removed: List[str],
+) -> bool:
+    if not added and not removed:
+        return False
+
+    container = _locate_container(doc, subkey, create_env=subkey is None)
+    if container is None:
+        return False
+
+    modified = False
+
+    for key in removed:
+        if key in container:
+            del container[key]
+            modified = True
+
+    for key, leaf_type in added.items():
+        if key in container:
+            continue
+        container[key] = _BLANK_BY_TYPE[leaf_type]
+        modified = True
+
+    return modified
+
+
+def _locate_container(
+    doc: CommentedMap, subkey: Optional[str], create_env: bool
+) -> Optional[CommentedMap]:
+    if subkey is None:
+        env = doc.get("env")
+        if not isinstance(env, CommentedMap):
+            if env is None and create_env:
+                new = CommentedMap()
+                doc["env"] = new
+                return new
+            return None
+        return env
+
+    parent = doc.get(subkey)
+    if not isinstance(parent, CommentedMap):
+        return None
+    env = parent.get("env")
+    if not isinstance(env, CommentedMap):
+        return None
+    return env

--- a/actions/update-helm-chart/settings_sync/pr_body.py
+++ b/actions/update-helm-chart/settings_sync/pr_body.py
@@ -1,0 +1,53 @@
+"""Render the two PR-body fragments produced by the settings-sync phase."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from .flatten import LeafType
+
+
+def _release_url(source_repo: str, tag: str) -> str:
+    return f"https://github.com/{source_repo}/releases/tag/{tag}"
+
+
+def render_release_line(app_name: str, source_repo: str, release_tag: str) -> str:
+    url = _release_url(source_repo, release_tag)
+    return (
+        f"Automated update for {app_name} to version "
+        f"[{release_tag}]({url})."
+    )
+
+
+def render_settings_section(
+    source_repo: str,
+    release_tag: str,
+    readme_path: Optional[str],
+    added: Dict[str, LeafType],
+    removed: List[str],
+) -> Optional[str]:
+    if not added and not removed:
+        return None
+
+    url = _release_url(source_repo, release_tag)
+    lines: list[str] = ["## Settings changes to review", ""]
+    lead = (
+        f"The following settings were introduced in [{release_tag}]({url})."
+    )
+    if readme_path:
+        lead += f"\nREADME updates may be needed in {readme_path}."
+    lines.append(lead)
+    lines.append("")
+
+    if added:
+        lines.append("### Added")
+        for key in sorted(added.keys()):
+            lines.append(f"- `{key}`")
+        lines.append("")
+
+    if removed:
+        lines.append("### Removed")
+        for key in sorted(removed):
+            lines.append(f"- `{key}`")
+        lines.append("")
+
+    return "\n".join(lines).rstrip("\n")

--- a/actions/update-helm-chart/settings_sync/runner.py
+++ b/actions/update-helm-chart/settings_sync/runner.py
@@ -1,0 +1,142 @@
+"""End-to-end orchestration of the settings-sync phase."""
+from __future__ import annotations
+
+import io
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ruamel.yaml import YAML
+
+from . import git_io
+from .diff import compute_diff
+from .flatten import LeafType, flatten_angular, flatten_dotnet
+from .jsonc import strip_jsonc_comments
+from . import patch_angular, patch_dotnet
+
+
+class SettingsSyncError(RuntimeError):
+    """Raised when settings-sync cannot proceed."""
+
+
+@dataclass(frozen=True)
+class RunResult:
+    previous_tag: Optional[str]
+    added: Dict[str, LeafType]
+    removed: List[str]
+    child_modified: bool
+    parent_modified: bool
+
+
+_yaml = YAML()
+_yaml.preserve_quotes = True
+
+
+def run(
+    *,
+    app_repo_dir: Path,
+    helm_repo_dir: Path,
+    settings_file: str,
+    settings_file_kind: str,
+    chart_file: str,
+    parent_chart_file: Optional[str],
+    release_tag: str,
+) -> RunResult:
+    if settings_file_kind not in ("dotnet-appsettings", "angular-settings"):
+        raise SettingsSyncError(
+            f"Unknown settings_file_kind: {settings_file_kind!r}"
+        )
+
+    prev_tag = git_io.previous_tag(app_repo_dir, release_tag)
+
+    prev_content = (
+        git_io.show_file_at_ref(app_repo_dir, prev_tag, settings_file)
+        if prev_tag
+        else None
+    )
+    new_content = git_io.show_file_at_ref(
+        app_repo_dir, release_tag, settings_file
+    )
+    if new_content is None:
+        raise SettingsSyncError(
+            f"Settings file {settings_file!r} not found at {release_tag}."
+        )
+
+    prev_flat = _parse_and_flatten(prev_content or "{}", settings_file_kind)
+    new_flat = _parse_and_flatten(new_content, settings_file_kind)
+
+    diff = compute_diff(prev_flat, new_flat)
+
+    child_values_path = (
+        helm_repo_dir / Path(chart_file).parent / "values.yaml"
+    ).resolve()
+    parent_values_path = (
+        (helm_repo_dir / Path(parent_chart_file).parent / "values.yaml").resolve()
+        if parent_chart_file
+        else None
+    )
+
+    subkey = Path(chart_file).parent.name
+
+    child_modified = _apply(
+        child_values_path, settings_file_kind, None, diff.added, diff.removed
+    )
+    parent_modified = False
+    if parent_values_path is not None:
+        parent_modified = _apply(
+            parent_values_path,
+            settings_file_kind,
+            subkey,
+            diff.added,
+            diff.removed,
+        )
+
+    return RunResult(
+        previous_tag=prev_tag,
+        added=diff.added,
+        removed=diff.removed,
+        child_modified=child_modified,
+        parent_modified=parent_modified,
+    )
+
+
+def _parse_and_flatten(raw: str, kind: str) -> Dict[str, LeafType]:
+    if kind == "dotnet-appsettings":
+        cleaned = strip_jsonc_comments(raw)
+        try:
+            data = json.loads(cleaned) if cleaned.strip() else {}
+        except json.JSONDecodeError as exc:
+            raise SettingsSyncError(f"Failed to parse appsettings: {exc}")
+        return flatten_dotnet(data)
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        raise SettingsSyncError(f"Failed to parse angular settings: {exc}")
+    return flatten_angular(data)
+
+
+def _apply(
+    values_path: Path,
+    kind: str,
+    subkey: Optional[str],
+    added: Dict[str, LeafType],
+    removed: List[str],
+) -> bool:
+    if not values_path.exists():
+        return False
+    doc = _yaml.load(values_path.read_text())
+    if doc is None:
+        return False
+
+    if kind == "dotnet-appsettings":
+        changed = patch_dotnet.patch_values(doc, subkey, added, removed)
+    else:
+        changed = patch_angular.patch_values(doc, subkey, added, removed)
+
+    if changed:
+        buf = io.StringIO()
+        _yaml.dump(doc, buf)
+        text = patch_angular.finalize_dump(buf.getvalue(), doc)
+        values_path.write_text(text)
+    return changed

--- a/actions/update-helm-chart/tests/conftest.py
+++ b/actions/update-helm-chart/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Shared pytest fixtures for update-helm-chart tests."""
+import sys
+from pathlib import Path
+
+# Make the action directory importable so `import settings_sync` and
+# `import update_helm_chart` resolve when running pytest from anywhere.
+ACTION_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ACTION_DIR))

--- a/actions/update-helm-chart/tests/test_cli_integration.py
+++ b/actions/update-helm-chart/tests/test_cli_integration.py
@@ -1,0 +1,86 @@
+"""Integration test for the update_helm_chart.py CLI wiring.
+
+We can't mock git_io across a subprocess boundary, so this test initializes a
+real git repo with the settings file tagged at two versions and invokes the
+script end-to-end.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, capture_output=True)
+
+
+def _init_git_repo_with_two_tags(
+    repo: Path, settings_file: str, prev_content: str, new_content: str
+) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init", "-q", "-b", "main"], cwd=repo)
+    _run(["git", "config", "user.email", "t@t"], cwd=repo)
+    _run(["git", "config", "user.name", "t"], cwd=repo)
+    target = repo / settings_file
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(prev_content)
+    _run(["git", "add", "."], cwd=repo)
+    _run(["git", "commit", "-q", "-m", "prev"], cwd=repo)
+    _run(["git", "tag", "v2.5.0"], cwd=repo)
+    target.write_text(new_content)
+    _run(["git", "add", "."], cwd=repo)
+    _run(["git", "commit", "-q", "-m", "new"], cwd=repo)
+    _run(["git", "tag", "v2.6.0"], cwd=repo)
+
+
+def test_cli_end_to_end_emits_settings_outputs(tmp_path: Path) -> None:
+    app_repo = tmp_path / "app"
+    settings_path = "appsettings.json"
+    _init_git_repo_with_two_tags(
+        app_repo,
+        settings_path,
+        prev_content=json.dumps({"A": ""}),
+        new_content=json.dumps({"A": "", "B": True}),
+    )
+
+    helm_repo = tmp_path / "helm"
+    chart_dir = helm_repo / "charts" / "player" / "charts" / "player-api"
+    chart_dir.mkdir(parents=True)
+    (chart_dir / "Chart.yaml").write_text(
+        'apiVersion: v2\nname: player-api\nversion: 1.0.0\nappVersion: "2.5.0"\n'
+    )
+    (chart_dir / "values.yaml").write_text('env:\n  Existing: ""\n')
+
+    gh_out = tmp_path / "gh_output"
+    gh_out.write_text("")
+
+    script = Path(__file__).resolve().parents[1] / "update_helm_chart.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--helm-repo-dir", str(helm_repo),
+            "--chart-file", "charts/player/charts/player-api/Chart.yaml",
+            "--release-tag", "v2.6.0",
+            "--app-name", "Player API",
+            "--github-output", str(gh_out),
+            "--settings-file", settings_path,
+            "--settings-file-kind", "dotnet-appsettings",
+            "--source-repo", "cmu-sei/Player.Api",
+            "--app-repo-dir", str(app_repo),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    output = gh_out.read_text()
+    assert "settings_changed=true" in output
+    assert "settings_added=" in output
+    assert "previous_release_tag=v2.5.0" in output
+
+    values_text = (chart_dir / "values.yaml").read_text()
+    assert "Existing" in values_text  # preserved
+    assert "B" in values_text  # newly added

--- a/actions/update-helm-chart/tests/test_diff.py
+++ b/actions/update-helm-chart/tests/test_diff.py
@@ -1,0 +1,40 @@
+from settings_sync.diff import compute_diff, Diff
+from settings_sync.flatten import LeafType
+
+
+def test_added_and_removed_computed_from_two_maps():
+    prev = {"A": LeafType.STRING, "B": LeafType.BOOL}
+    new = {"B": LeafType.BOOL, "C": LeafType.NUMBER}
+    diff = compute_diff(prev, new)
+    assert diff == Diff(added={"C": LeafType.NUMBER}, removed=["A"])
+
+
+def test_identical_maps_yield_empty_diff():
+    prev = {"A": LeafType.STRING}
+    new = {"A": LeafType.STRING}
+    diff = compute_diff(prev, new)
+    assert diff.added == {}
+    assert diff.removed == []
+
+
+def test_empty_previous_means_everything_added():
+    prev: dict = {}
+    new = {"A": LeafType.STRING, "B": LeafType.BOOL}
+    diff = compute_diff(prev, new)
+    assert diff.added == {"A": LeafType.STRING, "B": LeafType.BOOL}
+    assert diff.removed == []
+
+
+def test_type_change_is_not_a_modification():
+    prev = {"A": LeafType.STRING}
+    new = {"A": LeafType.BOOL}
+    diff = compute_diff(prev, new)
+    assert diff.added == {}
+    assert diff.removed == []
+
+
+def test_removed_list_sorted_alphabetically():
+    prev = {"Z": LeafType.STRING, "A": LeafType.STRING, "M": LeafType.STRING}
+    new: dict = {}
+    diff = compute_diff(prev, new)
+    assert diff.removed == ["A", "M", "Z"]

--- a/actions/update-helm-chart/tests/test_flatten.py
+++ b/actions/update-helm-chart/tests/test_flatten.py
@@ -1,0 +1,60 @@
+from settings_sync.flatten import flatten_dotnet, flatten_angular, LeafType
+
+
+def test_dotnet_flattens_nested_scalars():
+    data = {
+        "PathBase": "",
+        "Authorization": {"Authority": "x", "RequireHttpsMetadata": False},
+    }
+    result = flatten_dotnet(data)
+    assert result == {
+        "PathBase": LeafType.STRING,
+        "Authorization__Authority": LeafType.STRING,
+        "Authorization__RequireHttpsMetadata": LeafType.BOOL,
+    }
+
+
+def test_dotnet_scalar_array_emits_single_index_zero():
+    data = {"CorsPolicy": {"Origins": ["http://a", "http://b"]}}
+    result = flatten_dotnet(data)
+    assert result == {"CorsPolicy__Origins__0": LeafType.STRING}
+
+
+def test_dotnet_empty_container_is_skipped():
+    data = {"SeedData": {"Permissions": [], "Roles": {}}}
+    result = flatten_dotnet(data)
+    assert result == {}
+
+
+def test_dotnet_number_and_bool_types():
+    data = {"SignalR": {"BufferSize": 100000, "Enabled": True}}
+    result = flatten_dotnet(data)
+    assert result == {
+        "SignalR__BufferSize": LeafType.NUMBER,
+        "SignalR__Enabled": LeafType.BOOL,
+    }
+
+
+def test_angular_flattens_to_json_pointer_paths():
+    data = {
+        "ApiUrl": "",
+        "OIDCSettings": {"authority": "", "automaticSilentRenew": True},
+    }
+    result = flatten_angular(data)
+    assert result == {
+        "/ApiUrl": LeafType.STRING,
+        "/OIDCSettings/authority": LeafType.STRING,
+        "/OIDCSettings/automaticSilentRenew": LeafType.BOOL,
+    }
+
+
+def test_angular_scalar_array_emits_index_zero_pointer():
+    data = {"Scopes": ["openid", "profile"]}
+    result = flatten_angular(data)
+    assert result == {"/Scopes/0": LeafType.STRING}
+
+
+def test_angular_empty_container_skipped():
+    data = {"Empty": [], "AlsoEmpty": {}}
+    result = flatten_angular(data)
+    assert result == {}

--- a/actions/update-helm-chart/tests/test_git_io.py
+++ b/actions/update-helm-chart/tests/test_git_io.py
@@ -1,0 +1,52 @@
+import subprocess
+
+import pytest
+
+from settings_sync import git_io
+
+
+def test_list_tags_returns_tags_in_version_order(tmp_path, monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="v2.6.0\nv2.5.2\nv2.5.1\n", stderr=""
+        )
+
+    monkeypatch.setattr(git_io.subprocess, "run", fake_run)
+    tags = git_io.list_tags(tmp_path)
+    assert tags == ["v2.6.0", "v2.5.2", "v2.5.1"]
+    assert calls == [["git", "-C", str(tmp_path), "tag", "--list", "--sort=-v:refname"]]
+
+
+def test_previous_tag_returns_tag_before_target(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        git_io, "list_tags", lambda _: ["v2.6.0", "v2.5.2", "v2.5.1"]
+    )
+    assert git_io.previous_tag(tmp_path, "v2.6.0") == "v2.5.2"
+    assert git_io.previous_tag(tmp_path, "v2.5.1") is None
+
+
+def test_previous_tag_returns_none_when_target_not_found(tmp_path, monkeypatch):
+    monkeypatch.setattr(git_io, "list_tags", lambda _: ["v2.5.2", "v2.5.1"])
+    assert git_io.previous_tag(tmp_path, "v2.6.0") is None
+
+
+def test_show_file_at_ref_returns_content(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["git", "-C", str(tmp_path), "show", "v1.0.0:x.json"]
+        return subprocess.CompletedProcess(cmd, 0, stdout='{"a": 1}', stderr="")
+
+    monkeypatch.setattr(git_io.subprocess, "run", fake_run)
+    assert git_io.show_file_at_ref(tmp_path, "v1.0.0", "x.json") == '{"a": 1}'
+
+
+def test_show_file_at_ref_returns_none_when_file_missing(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd, 128, stdout="", stderr="fatal: path 'x.json' does not exist"
+        )
+
+    monkeypatch.setattr(git_io.subprocess, "run", fake_run)
+    assert git_io.show_file_at_ref(tmp_path, "v1.0.0", "x.json") is None

--- a/actions/update-helm-chart/tests/test_jsonc.py
+++ b/actions/update-helm-chart/tests/test_jsonc.py
@@ -1,0 +1,33 @@
+import json
+
+from settings_sync.jsonc import strip_jsonc_comments
+
+
+def test_strips_line_comments_outside_strings():
+    src = '{\n  "a": 1, // trailing\n  "b": 2\n}'
+    result = strip_jsonc_comments(src)
+    assert json.loads(result) == {"a": 1, "b": 2}
+
+
+def test_preserves_double_slashes_inside_strings():
+    src = '{"url": "http://example.com"}'
+    result = strip_jsonc_comments(src)
+    assert json.loads(result) == {"url": "http://example.com"}
+
+
+def test_preserves_escaped_quotes_in_strings():
+    src = '{"s": "a\\"b // not a comment"}'
+    result = strip_jsonc_comments(src)
+    assert json.loads(result) == {"s": 'a"b // not a comment'}
+
+
+def test_strips_commented_out_object_leaving_empty_array():
+    src = '{\n  "seeds": [\n    // { "name": "x" }\n  ]\n}'
+    result = strip_jsonc_comments(src)
+    assert json.loads(result) == {"seeds": []}
+
+
+def test_strips_block_comments():
+    src = '{ "a": 1 /* inline */, "b": 2 }'
+    result = strip_jsonc_comments(src)
+    assert json.loads(result) == {"a": 1, "b": 2}

--- a/actions/update-helm-chart/tests/test_patch_angular.py
+++ b/actions/update-helm-chart/tests/test_patch_angular.py
@@ -117,3 +117,55 @@ def test_operates_under_subkey_in_parent_values():
     )
     assert changed is True
     assert json.loads(data["player-ui"]["settings"]) == {"A": False}
+
+
+def test_settings_yaml_splice_scoped_to_target_subkey():
+    src = textwrap.dedent(
+        """\
+        player-api:
+          env:
+            Existing__Key: ""
+        player-ui:
+          settingsYaml: {}
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data,
+        subkey="player-api",
+        added={"/OIDCSettings/authority": LeafType.STRING},
+        removed=[],
+    )
+    # player-api has no settings/settingsYaml block, so no change should occur
+    # and the player-ui settingsYaml must NOT be spliced into.
+    assert changed is False
+    out = _dump(data)
+    assert "OIDCSettings" not in out
+    assert "authority" not in out
+
+
+def test_settings_yaml_splice_targets_correct_sibling_block():
+    src = textwrap.dedent(
+        """\
+        player-api:
+          settingsYaml: {}
+        player-ui:
+          settingsYaml: {}
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data,
+        subkey="player-ui",
+        added={"/OIDCSettings/authority": LeafType.STRING},
+        removed=[],
+    )
+    assert changed is True
+    out = _dump(data)
+    # The splice must land under player-ui, not under player-api.
+    api_idx = out.index("player-api:")
+    ui_idx = out.index("player-ui:")
+    oidc_idx = out.index("# OIDCSettings:")
+    assert ui_idx < oidc_idx
+    # And the player-api block (between api_idx and ui_idx) must not contain it.
+    assert "OIDCSettings" not in out[api_idx:ui_idx]

--- a/actions/update-helm-chart/tests/test_patch_angular.py
+++ b/actions/update-helm-chart/tests/test_patch_angular.py
@@ -1,0 +1,119 @@
+import io
+import json
+import textwrap
+
+from ruamel.yaml import YAML
+
+from settings_sync.flatten import LeafType
+from settings_sync.patch_angular import finalize_dump, patch_values
+
+yaml = YAML()
+yaml.preserve_quotes = True
+
+
+def _roundtrip(text: str):
+    return yaml.load(io.StringIO(text))
+
+
+def _dump(data) -> str:
+    buf = io.StringIO()
+    yaml.dump(data, buf)
+    return finalize_dump(buf.getvalue(), data)
+
+
+def test_updates_stringified_settings_json_adding_blank_by_type():
+    src = textwrap.dedent(
+        """\
+        settings: '{"ApiUrl": ""}'
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data,
+        subkey=None,
+        added={
+            "/OIDCSettings/authority": LeafType.STRING,
+            "/OIDCSettings/automaticSilentRenew": LeafType.BOOL,
+        },
+        removed=[],
+    )
+    assert changed is True
+    settings_str = data["settings"]
+    parsed = json.loads(settings_str)
+    assert parsed["OIDCSettings"]["authority"] == ""
+    assert parsed["OIDCSettings"]["automaticSilentRenew"] is False
+    assert parsed["ApiUrl"] == ""
+
+
+def test_removes_key_from_stringified_settings_json():
+    src = textwrap.dedent(
+        """\
+        settings: '{"Keep": "", "Drop": ""}'
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(data, subkey=None, added={}, removed=["/Drop"])
+    assert changed is True
+    parsed = json.loads(data["settings"])
+    assert parsed == {"Keep": ""}
+
+
+def test_updates_settingsYaml_appending_commented_lines():
+    src = textwrap.dedent(
+        """\
+        settingsYaml:
+          # ApiUrl: ""
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data,
+        subkey=None,
+        added={"/OIDCSettings/authority": LeafType.STRING},
+        removed=[],
+    )
+    assert changed is True
+    out = _dump(data)
+    assert "# OIDCSettings:" in out
+    assert '#   authority: ""' in out
+
+
+def test_skips_when_neither_settings_nor_settingsYaml_present():
+    src = "image: {}\n"
+    data = _roundtrip(src)
+    changed = patch_values(
+        data, subkey=None, added={"/X": LeafType.STRING}, removed=[]
+    )
+    assert changed is False
+
+
+def test_updates_both_blocks_when_both_present():
+    src = textwrap.dedent(
+        """\
+        settings: '{}'
+        settingsYaml: {}
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data, subkey=None, added={"/A": LeafType.STRING}, removed=[]
+    )
+    assert changed is True
+    assert json.loads(data["settings"]) == {"A": ""}
+    out = _dump(data)
+    assert '# A: ""' in out
+
+
+def test_operates_under_subkey_in_parent_values():
+    src = textwrap.dedent(
+        """\
+        player-ui:
+          settings: '{}'
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data, subkey="player-ui", added={"/A": LeafType.BOOL}, removed=[]
+    )
+    assert changed is True
+    assert json.loads(data["player-ui"]["settings"]) == {"A": False}

--- a/actions/update-helm-chart/tests/test_patch_dotnet.py
+++ b/actions/update-helm-chart/tests/test_patch_dotnet.py
@@ -1,0 +1,134 @@
+import io
+import textwrap
+
+from ruamel.yaml import YAML
+
+from settings_sync.flatten import LeafType
+from settings_sync.patch_dotnet import patch_values
+
+yaml = YAML()
+yaml.preserve_quotes = True
+
+
+def _roundtrip(text: str):
+    return yaml.load(io.StringIO(text))
+
+
+def _dump(data) -> str:
+    buf = io.StringIO()
+    yaml.dump(data, buf)
+    return buf.getvalue()
+
+
+def test_adds_new_keys_at_end_of_env_block():
+    src = textwrap.dedent(
+        """\
+        env:
+          Existing__Key: ""
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data,
+        subkey=None,
+        added={
+            "Authorization__NewSetting": LeafType.STRING,
+            "Logging__Enabled": LeafType.BOOL,
+        },
+        removed=[],
+    )
+    assert changed is True
+    out = _dump(data)
+    assert 'Authorization__NewSetting: ""' in out
+    assert "Logging__Enabled: false" in out
+    assert out.index("Existing__Key") < out.index("Authorization__NewSetting")
+
+
+def test_removes_existing_keys():
+    src = textwrap.dedent(
+        """\
+        env:
+          Keep__Me: ""
+          Remove__Me: ""
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data, subkey=None, added={}, removed=["Remove__Me"]
+    )
+    assert changed is True
+    out = _dump(data)
+    assert "Keep__Me" in out
+    assert "Remove__Me" not in out
+
+
+def test_creates_env_block_when_missing_at_root():
+    src = "image: {}\n"
+    data = _roundtrip(src)
+    changed = patch_values(
+        data, subkey=None, added={"New__Key": LeafType.STRING}, removed=[]
+    )
+    assert changed is True
+    out = _dump(data)
+    assert "env:" in out
+    assert 'New__Key: ""' in out
+
+
+def test_skips_parent_when_env_block_missing_under_subkey():
+    src = textwrap.dedent(
+        """\
+        player-api:
+          image:
+            repository: x
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data,
+        subkey="player-api",
+        added={"New__Key": LeafType.STRING},
+        removed=[],
+    )
+    assert changed is False
+    assert "env:" not in _dump(data)
+
+
+def test_updates_env_block_under_subkey_when_present():
+    src = textwrap.dedent(
+        """\
+        player-api:
+          env:
+            Existing__Key: ""
+        """
+    )
+    data = _roundtrip(src)
+    changed = patch_values(
+        data,
+        subkey="player-api",
+        added={"New__Key": LeafType.NUMBER},
+        removed=[],
+    )
+    assert changed is True
+    out = _dump(data)
+    assert "New__Key: 0" in out
+
+
+def test_empty_diff_returns_false_and_noop():
+    src = "env:\n  Keep: \"\"\n"
+    data = _roundtrip(src)
+    changed = patch_values(data, subkey=None, added={}, removed=[])
+    assert changed is False
+    assert _dump(data) == src
+
+
+def test_scalar_array_added_as_index_zero_string():
+    src = "env: {}\n"
+    data = _roundtrip(src)
+    changed = patch_values(
+        data,
+        subkey=None,
+        added={"CorsPolicy__Origins__0": LeafType.STRING},
+        removed=[],
+    )
+    assert changed is True
+    assert 'CorsPolicy__Origins__0: ""' in _dump(data)

--- a/actions/update-helm-chart/tests/test_pr_body.py
+++ b/actions/update-helm-chart/tests/test_pr_body.py
@@ -1,0 +1,78 @@
+from settings_sync.flatten import LeafType
+from settings_sync.pr_body import (
+    render_release_line,
+    render_settings_section,
+)
+
+
+def test_release_line_uses_markdown_link():
+    line = render_release_line(
+        app_name="Player API",
+        source_repo="cmu-sei/Player.Api",
+        release_tag="v2.6.0",
+    )
+    assert line == (
+        "Automated update for Player API to version "
+        "[v2.6.0](https://github.com/cmu-sei/Player.Api/releases/tag/v2.6.0)."
+    )
+
+
+def test_settings_section_none_when_no_changes():
+    section = render_settings_section(
+        source_repo="cmu-sei/Player.Api",
+        release_tag="v2.6.0",
+        readme_path="charts/player/README.md",
+        added={},
+        removed=[],
+    )
+    assert section is None
+
+
+def test_settings_section_added_only():
+    section = render_settings_section(
+        source_repo="cmu-sei/Player.Api",
+        release_tag="v2.6.0",
+        readme_path="charts/player/README.md",
+        added={"B__Key": LeafType.STRING, "A__Key": LeafType.STRING},
+        removed=[],
+    )
+    assert section is not None
+    assert "## Settings changes to review" in section
+    assert (
+        "The following settings were introduced in "
+        "[v2.6.0](https://github.com/cmu-sei/Player.Api/releases/tag/v2.6.0)."
+        in section
+    )
+    assert "README updates may be needed in charts/player/README.md." in section
+    assert "### Added" in section
+    assert section.index("`A__Key`") < section.index("`B__Key`")
+    assert "### Removed" not in section
+
+
+def test_settings_section_removed_only_omits_added_header():
+    section = render_settings_section(
+        source_repo="cmu-sei/Player.Api",
+        release_tag="v2.6.0",
+        readme_path=None,
+        added={},
+        removed=["X__Key"],
+    )
+    assert section is not None
+    assert "### Added" not in section
+    assert "### Removed" in section
+    assert "`X__Key`" in section
+    assert "README updates may be needed" not in section
+
+
+def test_settings_section_both_added_and_removed():
+    section = render_settings_section(
+        source_repo="cmu-sei/Player.Api",
+        release_tag="v2.6.0",
+        readme_path="charts/player/README.md",
+        added={"New__Key": LeafType.STRING},
+        removed=["Old__Key"],
+    )
+    assert section is not None
+    assert "### Added" in section
+    assert "### Removed" in section
+    assert section.index("### Added") < section.index("### Removed")

--- a/actions/update-helm-chart/tests/test_render_pr_section.py
+++ b/actions/update-helm-chart/tests/test_render_pr_section.py
@@ -1,0 +1,45 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_render_pr_section_cli_emits_section():
+    script = Path(__file__).resolve().parents[1] / "render_pr_section.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--source-repo", "cmu-sei/Player.Api",
+            "--release-tag", "v2.6.0",
+            "--readme-path", "charts/player/README.md",
+            "--added", json.dumps({"A__Key": "string"}),
+            "--removed", json.dumps(["Old__Key"]),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = proc.stdout
+    assert "## Settings changes to review" in out
+    assert "`A__Key`" in out
+    assert "`Old__Key`" in out
+
+
+def test_render_pr_section_cli_empty_input_prints_nothing():
+    script = Path(__file__).resolve().parents[1] / "render_pr_section.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--source-repo", "cmu-sei/Player.Api",
+            "--release-tag", "v2.6.0",
+            "--readme-path", "",
+            "--added", "{}",
+            "--removed", "[]",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert proc.stdout.strip() == ""

--- a/actions/update-helm-chart/tests/test_runner.py
+++ b/actions/update-helm-chart/tests/test_runner.py
@@ -1,0 +1,139 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from settings_sync import runner
+from settings_sync.flatten import LeafType
+
+
+class _FakeGit:
+    def __init__(self, tags, files):
+        self._tags = tags
+        self._files = files  # {(ref, path): content or None}
+
+    def list_tags(self, _):
+        return list(self._tags)
+
+    def previous_tag(self, _, target):
+        try:
+            idx = self._tags.index(target)
+        except ValueError:
+            return None
+        if idx + 1 >= len(self._tags):
+            return None
+        return self._tags[idx + 1]
+
+    def show_file_at_ref(self, _, ref, path):
+        return self._files.get((ref, path))
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_dotnet_end_to_end_updates_child_and_parent_and_returns_diff(
+    tmp_path: Path, monkeypatch
+):
+    app_repo = tmp_path / "app"
+    app_repo.mkdir()
+
+    helm_repo = tmp_path / "helm"
+    child_values = helm_repo / "charts" / "player" / "charts" / "player-api" / "values.yaml"
+    parent_values = helm_repo / "charts" / "player" / "values.yaml"
+    _write(child_values, "env:\n  Existing__Key: \"\"\n")
+    _write(
+        parent_values,
+        "player-api:\n  env:\n    Existing__Key: \"\"\n",
+    )
+
+    prev_appsettings = json.dumps({"Existing": {"Key": ""}})
+    new_appsettings = json.dumps(
+        {"Existing": {"Key": ""}, "New": {"Key": "x", "Flag": True}}
+    )
+
+    fake = _FakeGit(
+        tags=["v2.6.0", "v2.5.0"],
+        files={
+            ("v2.5.0", "Player.Api/appsettings.json"): prev_appsettings,
+            ("v2.6.0", "Player.Api/appsettings.json"): new_appsettings,
+        },
+    )
+    monkeypatch.setattr(runner, "git_io", fake)
+
+    result = runner.run(
+        app_repo_dir=app_repo,
+        helm_repo_dir=helm_repo,
+        settings_file="Player.Api/appsettings.json",
+        settings_file_kind="dotnet-appsettings",
+        chart_file="charts/player/charts/player-api/Chart.yaml",
+        parent_chart_file="charts/player/Chart.yaml",
+        release_tag="v2.6.0",
+    )
+
+    assert result.previous_tag == "v2.5.0"
+    assert result.added == {
+        "New__Key": LeafType.STRING,
+        "New__Flag": LeafType.BOOL,
+    }
+    assert result.removed == []
+    child_text = child_values.read_text()
+    parent_text = parent_values.read_text()
+    assert "New__Key" in child_text and "New__Flag" in child_text
+    assert "New__Key" in parent_text and "New__Flag" in parent_text
+
+
+def test_missing_new_file_raises(tmp_path: Path, monkeypatch):
+    app_repo = tmp_path / "app"
+    app_repo.mkdir()
+    helm_repo = tmp_path / "helm"
+    _write(
+        helm_repo / "charts" / "player" / "charts" / "player-api" / "values.yaml",
+        "env: {}\n",
+    )
+
+    fake = _FakeGit(
+        tags=["v1.0.0"],
+        files={("v1.0.0", "settings.json"): None},
+    )
+    monkeypatch.setattr(runner, "git_io", fake)
+
+    with pytest.raises(runner.SettingsSyncError):
+        runner.run(
+            app_repo_dir=app_repo,
+            helm_repo_dir=helm_repo,
+            settings_file="settings.json",
+            settings_file_kind="dotnet-appsettings",
+            chart_file="charts/player/charts/player-api/Chart.yaml",
+            parent_chart_file=None,
+            release_tag="v1.0.0",
+        )
+
+
+def test_no_previous_tag_treats_prev_as_empty(tmp_path: Path, monkeypatch):
+    app_repo = tmp_path / "app"
+    app_repo.mkdir()
+    helm_repo = tmp_path / "helm"
+    _write(
+        helm_repo / "charts" / "player" / "charts" / "player-api" / "values.yaml",
+        "env: {}\n",
+    )
+
+    fake = _FakeGit(
+        tags=["v1.0.0"],
+        files={("v1.0.0", "s.json"): json.dumps({"A": "", "B": False})},
+    )
+    monkeypatch.setattr(runner, "git_io", fake)
+
+    result = runner.run(
+        app_repo_dir=app_repo,
+        helm_repo_dir=helm_repo,
+        settings_file="s.json",
+        settings_file_kind="dotnet-appsettings",
+        chart_file="charts/player/charts/player-api/Chart.yaml",
+        parent_chart_file=None,
+        release_tag="v1.0.0",
+    )
+    assert result.previous_tag is None
+    assert set(result.added.keys()) == {"A", "B"}

--- a/actions/update-helm-chart/update_helm_chart.py
+++ b/actions/update-helm-chart/update_helm_chart.py
@@ -19,9 +19,13 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from settings_sync import SettingsSyncError, run as run_settings_sync  # noqa: E402
 
 SEMVER_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
 
@@ -220,7 +224,33 @@ def handle_update(args: argparse.Namespace) -> int:
             args.app_name, result.new_app_version, args.release_tag
         )
 
-    has_changes = result.chart_modified or bool(parent_update)
+    settings_added: Dict[str, str] = {}
+    settings_removed: list = []
+    previous_release_tag = ""
+    settings_changed = False
+
+    if args.settings_file:
+        if not args.settings_file_kind:
+            raise ChartUpdateError(
+                "--settings-file-kind is required when --settings-file is set."
+            )
+        sync = run_settings_sync(
+            app_repo_dir=Path(args.app_repo_dir).resolve(),
+            helm_repo_dir=helm_repo_dir,
+            settings_file=args.settings_file,
+            settings_file_kind=args.settings_file_kind,
+            chart_file=args.chart_file,
+            parent_chart_file=args.parent_chart_file or None,
+            release_tag=args.release_tag,
+        )
+        settings_added = {k: v.value for k, v in sync.added.items()}
+        settings_removed = list(sync.removed)
+        previous_release_tag = sync.previous_tag or ""
+        settings_changed = bool(settings_added or settings_removed)
+
+    has_changes = (
+        result.chart_modified or bool(parent_update) or settings_changed
+    )
 
     result_payload: Dict[str, Any] = {
         "old_app_version": result.old_app_version,
@@ -232,6 +262,10 @@ def handle_update(args: argparse.Namespace) -> int:
         "parent_chart_update": parent_update or None,
         "branch_name": branch_name,
         "has_changes": has_changes,
+        "settings_added": settings_added,
+        "settings_removed": settings_removed,
+        "settings_changed": settings_changed,
+        "previous_release_tag": previous_release_tag,
     }
 
     if args.result_file:
@@ -252,6 +286,10 @@ def handle_update(args: argparse.Namespace) -> int:
             "chart_modified": result.chart_modified,
             "branch_name": branch_name,
             "has_changes": has_changes,
+            "settings_added": settings_added,
+            "settings_removed": settings_removed,
+            "settings_changed": settings_changed,
+            "previous_release_tag": previous_release_tag,
         },
     )
 
@@ -269,6 +307,10 @@ def parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
     parser.add_argument("--result-file", default="")
     parser.add_argument("--app-name", default="")
     parser.add_argument("--github-output", default="")
+    parser.add_argument("--settings-file", default="")
+    parser.add_argument("--settings-file-kind", default="")
+    parser.add_argument("--source-repo", default="")
+    parser.add_argument("--app-repo-dir", default=".")
     return parser.parse_args(argv)
 
 
@@ -276,7 +318,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parse_args(argv)
     try:
         return handle_update(args)
-    except ChartUpdateError as exc:
+    except (ChartUpdateError, SettingsSyncError) as exc:
         print(f"[update_helm_chart] {exc}", file=sys.stderr)
         return 1
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                            
  Extends the `update-helm-chart` composite action with an optional `settings-sync` phase that diffs the app's settings file between the previous and new release tags, propagates added/removed leaf keys into the helm chart's values.yaml (child + optional parent), and annotates the helm-charts PR body with a "Settings changes to review" section so a human can update the README.                                                                                                                                                                                                                                   

                                                                                                                       
  - Two new inputs: `settings_file`, `settings_file_kind` (`dotnet-appsettings` or `angular-settings`)                                                                                                                                                                                                                  
  - New outputs: `settings_changed`, `settings_added`, `settings_removed`, `previous_release_tag`                                                                                                                                                                                                                       
  - PR body now includes markdown links to the app release page                                                                                                                                                                                                                                                         
  - No README edits performed automatically — humans handle that during review                                                                                                                                                                                                                                          
  - Fully opt-in; workflows that don't set `settings_file` see no behavior change                                                                                                                                                                                                                                       

  ## Test plan                                                                                                                                                                                                                                                                                                          
  - [x] Unit tests: 46 tests under `actions/update-helm-chart/tests/` covering JSONC stripping, flattening (dotnet + angular), diffing, git I/O, both patchers, PR body rendering, runner orchestration, and CLI wiring                                                                                                 
  - [x] End-to-end validation: triggered real releases on sei-jbooz/Player.Api; verified values.yaml updates and PR body sections land correctly against sei-jbooz/helm-charts   