### PR TITLE
Adds checkout step in update-helm-chart action

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ When `settings_file` and `settings_file_kind` are set, the action additionally d
 
 New keys are inserted with blank placeholders by JSON type (`""`, `false`, `0`). No README edits are made automatically. Re-running the action for the same release is a no-op.
 
+When `settings_file` is set the action checks out the calling repository at `release_tag` with full tag history into a `source/` sub-path. Consumers do not need to add their own `actions/checkout` step.
+
 #### Example Usage
 
 ```yaml

--- a/actions/update-helm-chart/action.yaml
+++ b/actions/update-helm-chart/action.yaml
@@ -114,8 +114,17 @@ runs:
         owner: ${{ steps.repo_meta.outputs.owner }}
         repositories: ${{ steps.repo_meta.outputs.name }}
 
+    - name: Checkout source repository
+      if: inputs.settings_file != ''
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ inputs.release_tag }}
+        path: source
+        fetch-depth: 0
+
     - name: Checkout Helm charts repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ inputs.helm_chart_repo }}
         token: ${{ steps.mint_token.outputs.token || inputs.helm_repo_token || env.GH_TOKEN || github.token }}
@@ -123,7 +132,7 @@ runs:
         ref: main
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 
@@ -148,7 +157,7 @@ runs:
           --settings-file "${{ inputs.settings_file }}" \
           --settings-file-kind "${{ inputs.settings_file_kind }}" \
           --source-repo "$SOURCE_REPO" \
-          --app-repo-dir "$GITHUB_WORKSPACE"
+          --app-repo-dir "source"
       shell: bash
 
     - name: Derive README path


### PR DESCRIPTION
Added a step to checkout the source rpeo in the `update-helm-chart` action. This fixes a bug where the action does not succeed when invoked without first doing a checkout step. 