### PR TITLE
Bump Actions Versions and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/.github/workflows"
+      - "/actions/header"
+      - "/actions/update-helm-chart"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/actions/header/action.yaml
+++ b/actions/header/action.yaml
@@ -15,11 +15,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.head_ref }}
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
         architecture: "x64"
@@ -47,7 +47,7 @@ runs:
 
     - name: Push changes
       if: env.FILESCHANGED == 'TRUE'
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v1.1.0
       with:
         github_token: ${{ inputs.github_token }}
         branch: ${{ github.head_ref }}

--- a/actions/update-helm-chart/action.yaml
+++ b/actions/update-helm-chart/action.yaml
@@ -107,7 +107,7 @@ runs:
       if: >
         (inputs.github_app_id != '') &&
         (inputs.github_app_private_key != '')
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.github_app_id }}
         private-key: ${{ inputs.github_app_private_key }}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                     
  - Bump GitHub Actions to current major versions across both composite actions.                                                                                                                                                                                                                                                                                     
  - Pin `ad-m/github-push-action` from the moving `@master` branch ref to `@v1.1.0` so Dependabot can manage it going forward.                                                                                                                                                                                                                                       
  - Add `.github/dependabot.yml` to keep all action versions current automatically.                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                     
  ## Version bumps                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                     
  | File | Action | From | To |                                                                                                                                                                                                                                                                                                                                      
  |---|---|---|---|                                               
  | `actions/header/action.yaml` | `actions/checkout` | `v3` | `v6` |                                                                                                                                                                                                                                                                                                
  | `actions/header/action.yaml` | `actions/setup-python` | `v2` | `v6` |                                                                                                                                                                                                                                                                                            
  | `actions/header/action.yaml` | `ad-m/github-push-action` | `@master` | `@v1.1.0` |                                                                                                                                                                                                                                                                               
  | `actions/update-helm-chart/action.yaml` | `actions/create-github-app-token` | `v1` | `v3` |                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                     
  `docker/setup-buildx-action`, `docker/login-action`, `docker/metadata-action`, and `docker/build-push-action` in `.github/workflows/docker-build.yaml` were already at their latest majors — no change.                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                     
  **No input/output contract changes were required for any consumer of these composite actions.**                                                                                                                                                                                                                                                                        
                                                                  
  ## Dependabot configuration                                                                                                                                                                                                                                                                                                                                        
                                                                  
  New file `.github/dependabot.yml`:                                                                                                                                                                                                                                                                                                                                 
                                                                  
  - Ecosystem: `github-actions`.                                                                                                                                                                                                                                                                                                                                     
  - Schedule: `monthly` — Dependabot's `monthly` interval runs on the first day of each month.
  - Grouping: a single wildcard group `github-actions` batches every action update into one PR per run rather than one PR per dependency.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                     
  ## Runtime requirement                                                                                                                                                                                                                                                                                                                                             
                                                                  
  All bumped actions now run on Node 24, which requires GitHub Actions Runner **v2.329.0+** (driven by `actions/checkout@v6`'s move of persisted credentials from `.git/config` to `$RUNNER_TEMP`). **GitHub-hosted runners already satisfy this.** Any self-hosted runner consuming these actions must be on v2.329.0 or newer.                                         
                                                                  
  ## Deferred: `app-id` → `client-id` migration in `create-github-app-token`                                                                                                                                                                                                                                                                                         
                                                                  
  Bumping `actions/create-github-app-token` to `v3` surfaces a soft deprecation warning on the `app-id` input — v3.1.0 introduced `client-id` as the preferred input and marked `app-id` deprecated (still fully functional, no removal date announced).                                                                                                             
                                                                  
  We are **not** migrating to `client-id` in this PR for the following reasons:                                                                                                                                                                                                                                                                                      
                                                                  
  - App ID and Client ID are two distinct values on a GitHub App, so the migration is not a rename — every consumer repo would need a new secret value rotated in alongside the workflow change.                                                                                                                                                                     
  - The `github_app_id` input on this composite action is consumed by every Crucible service repo's `update-helm-chart.yml` workflow (Player API, VM API, Caster, Alloy, TopoMojo, Steamfitter, CITE, Gallery, Blueprint, Gameboard, etc.). Renaming the input is a breaking change for the composite action and would require a coordinated bump of `@update-helm-chart-vN` across all consumer repos.                                                                                                                                                                                                                                                                                                                 
