### PR TITLE
Support appsettings.conf files in update-helm-chart settings sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.venv

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The action:
 | `git_user_name` |  | Commit author name (`github-actions[bot]`). |
 | `git_user_email` |  | Commit author email (`41898282+github-actions[bot]@users.noreply.github.com`). |
 | `settings_file` |  | Path in the calling repo to the app settings file (e.g. `Player.Api/appsettings.json`). When set, enables the settings-sync phase. Omit to disable. |
-| `settings_file_kind` |  | One of `dotnet-appsettings` or `angular-settings`. Required when `settings_file` is set. |
+| `settings_file_kind` |  | One of `dotnet-appsettings`, `dotnet-conf`, or `angular-settings`. Required when `settings_file` is set. |
 
 #### Outputs
 
@@ -54,11 +54,27 @@ The action:
 
 When `settings_file` and `settings_file_kind` are set, the action additionally diffs the settings file between the previous and new release tags and propagates added/removed leaf keys:
 
-- Updates the `env:` block (for `dotnet-appsettings`) or `settings:` / `settingsYaml:` blocks (for `angular-settings`) in the child chart's `values.yaml`.
+- Updates the `env:` block (for `dotnet-appsettings` and `dotnet-conf`) or `settings:` / `settingsYaml:` blocks (for `angular-settings`) in the child chart's `values.yaml`.
 - Mirrors the same changes under the parent chart's subkey in the parent `values.yaml` when `parent_chart_file` is set and the subkey's block already exists. The subkey is derived from the chart folder name.
 - Appends a "Settings changes to review" section to the helm-charts PR body listing added/removed keys so a human can update the hand-curated chart README.
 
 New keys are inserted with blank placeholders by JSON type (`""`, `false`, `0`). No README edits are made automatically. Re-running the action for the same release is a no-op.
+
+##### Choosing between `dotnet-appsettings` and `dotnet-conf`
+
+Both kinds target ASP.NET Core configuration files and emit the same `Section__Key` flat-key shape into the chart's `env:` block. Pick the one that matches the file your app ships:
+
+| | `dotnet-appsettings` | `dotnet-conf` |
+| --- | --- | --- |
+| **File format** | JSON (with optional JSONC `//` and `/* */` comments) | INI-style: `Section__Key = value`, optionally prefixed with `#` to comment out a default |
+| **Typical filename** | `appsettings.json` | `appsettings.conf` |
+| **Type inference** | Yes — strings, bools, and numbers are detected from the JSON literal, so placeholders are typed (`""`, `false`, `0`) | No — the format is untyped, so every new key is added as `""` |
+| **Nested objects** | Walks the JSON tree to build `Section__Key` keys | Authors already write `Section__Key` directly; the parser just collects them line-by-line |
+| **Scalar arrays** | First element emitted as `Key__0` | Authors typically write `Key__0 = ...` directly; collected as-is |
+| **Comments** | JSONC line/block comments stripped before parsing | Lines starting with `#` (including dividers like `####`) are tolerated; entries are recognized whether commented out or active |
+| **Duplicate keys** | Last value wins (standard JSON semantics) | First occurrence wins; later duplicates (e.g., the example/dev sections at the bottom of `appsettings.conf`) are ignored |
+
+If the source file is a hybrid you control, prefer `dotnet-appsettings` so placeholders pick up the right type. Use `dotnet-conf` when the upstream project distributes a `.conf` file — feeding that text to the JSON parser would fail.
 
 When `settings_file` is set the action checks out the calling repository at `release_tag` with full tag history into a `source/` sub-path. Consumers do not need to add their own `actions/checkout` step.
 

--- a/actions/update-helm-chart/action.yaml
+++ b/actions/update-helm-chart/action.yaml
@@ -46,7 +46,7 @@ inputs:
     required: false
     default: ""
   settings_file_kind:
-    description: "Strategy for parsing settings_file. One of: dotnet-appsettings, angular-settings. Required when settings_file is set."
+    description: "Strategy for parsing settings_file. One of: dotnet-appsettings, dotnet-conf, angular-settings. Required when settings_file is set."
     required: false
     default: ""
 outputs:

--- a/actions/update-helm-chart/settings_sync/flatten.py
+++ b/actions/update-helm-chart/settings_sync/flatten.py
@@ -1,11 +1,15 @@
 """Flatten a parsed JSON object to a leaf-path -> type map.
 
-Two strategies:
+Three strategies:
   - flatten_dotnet: emits ASP.NET Core env-var style keys (`Section__Key`,
     `Array__0`). Skips containers that end up empty after JSONC comments are
     stripped upstream.
   - flatten_angular: emits JSON Pointer paths (`/Section/key`, `/Array/0`).
     Used for strict-JSON Angular settings files. Same empty-container skip.
+  - flatten_dotnet_conf: parses INI-style `appsettings.conf` text (lines like
+    `Section__Key = value`, optionally prefixed with `#` to comment them out)
+    and emits the same `Section__Key` shape as flatten_dotnet. Every entry is
+    treated as a STRING leaf since the .conf format is untyped.
 
 Only scalar-array elements are expanded, and only element 0 is emitted as a
 placeholder (matching existing values.yaml convention). Object arrays and
@@ -60,6 +64,27 @@ def _walk_dotnet(node: Any, path: list[str], out: Dict[str, LeafType]) -> None:
     if lt is None:
         return
     out["__".join(path)] = lt
+
+
+def flatten_dotnet_conf(raw: str) -> Dict[str, LeafType]:
+    result: Dict[str, LeafType] = {}
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            stripped = stripped.lstrip("#").strip()
+            if not stripped:
+                continue
+        if "=" not in stripped:
+            continue
+        key = stripped.split("=", 1)[0].strip()
+        if not key:
+            continue
+        if key in result:
+            continue
+        result[key] = LeafType.STRING
+    return result
 
 
 def flatten_angular(data: Any) -> Dict[str, LeafType]:

--- a/actions/update-helm-chart/settings_sync/runner.py
+++ b/actions/update-helm-chart/settings_sync/runner.py
@@ -11,7 +11,12 @@ from ruamel.yaml import YAML
 
 from . import git_io
 from .diff import compute_diff
-from .flatten import LeafType, flatten_angular, flatten_dotnet
+from .flatten import (
+    LeafType,
+    flatten_angular,
+    flatten_dotnet,
+    flatten_dotnet_conf,
+)
 from .jsonc import strip_jsonc_comments
 from . import patch_angular, patch_dotnet
 
@@ -43,7 +48,11 @@ def run(
     parent_chart_file: Optional[str],
     release_tag: str,
 ) -> RunResult:
-    if settings_file_kind not in ("dotnet-appsettings", "angular-settings"):
+    if settings_file_kind not in (
+        "dotnet-appsettings",
+        "dotnet-conf",
+        "angular-settings",
+    ):
         raise SettingsSyncError(
             f"Unknown settings_file_kind: {settings_file_kind!r}"
         )
@@ -109,6 +118,8 @@ def _parse_and_flatten(raw: str, kind: str) -> Dict[str, LeafType]:
         except json.JSONDecodeError as exc:
             raise SettingsSyncError(f"Failed to parse appsettings: {exc}")
         return flatten_dotnet(data)
+    if kind == "dotnet-conf":
+        return flatten_dotnet_conf(raw)
     try:
         data = json.loads(raw) if raw.strip() else {}
     except json.JSONDecodeError as exc:
@@ -129,7 +140,7 @@ def _apply(
     if doc is None:
         return False
 
-    if kind == "dotnet-appsettings":
+    if kind in ("dotnet-appsettings", "dotnet-conf"):
         changed = patch_dotnet.patch_values(doc, subkey, added, removed)
     else:
         changed = patch_angular.patch_values(doc, subkey, added, removed)

--- a/actions/update-helm-chart/tests/test_flatten.py
+++ b/actions/update-helm-chart/tests/test_flatten.py
@@ -1,4 +1,9 @@
-from settings_sync.flatten import flatten_dotnet, flatten_angular, LeafType
+from settings_sync.flatten import (
+    flatten_angular,
+    flatten_dotnet,
+    flatten_dotnet_conf,
+    LeafType,
+)
 
 
 def test_dotnet_flattens_nested_scalars():
@@ -58,3 +63,74 @@ def test_angular_empty_container_skipped():
     data = {"Empty": [], "AlsoEmpty": {}}
     result = flatten_angular(data)
     assert result == {}
+
+
+def test_dotnet_conf_treats_every_line_as_string_leaf():
+    raw = """\
+# PathBase =
+# Oidc__Audience = topomojo-api
+# Database__Provider = InMemory
+"""
+    result = flatten_dotnet_conf(raw)
+    assert result == {
+        "PathBase": LeafType.STRING,
+        "Oidc__Audience": LeafType.STRING,
+        "Database__Provider": LeafType.STRING,
+    }
+
+
+def test_dotnet_conf_ignores_section_dividers_and_blank_lines():
+    raw = """\
+####################
+## AppSettings
+####################
+
+## Some descriptive comment
+# Oidc__Authority = http://localhost:5000
+
+####################
+## Database
+####################
+# Database__Provider = InMemory
+"""
+    result = flatten_dotnet_conf(raw)
+    assert result == {
+        "Oidc__Authority": LeafType.STRING,
+        "Database__Provider": LeafType.STRING,
+    }
+
+
+def test_dotnet_conf_uncommented_lines_also_count_as_settings():
+    raw = """\
+PathBase = /api
+# Oidc__Audience = topomojo-api
+"""
+    result = flatten_dotnet_conf(raw)
+    assert result == {
+        "PathBase": LeafType.STRING,
+        "Oidc__Audience": LeafType.STRING,
+    }
+
+
+def test_dotnet_conf_blank_value_still_emits_key():
+    raw = "# Database__AdminId =\n"
+    result = flatten_dotnet_conf(raw)
+    assert result == {"Database__AdminId": LeafType.STRING}
+
+
+def test_dotnet_conf_duplicate_keys_keep_first_occurrence():
+    raw = """\
+# Oidc__Audience = topomojo-api
+# Oidc__Audience = dev-api
+"""
+    result = flatten_dotnet_conf(raw)
+    assert result == {"Oidc__Audience": LeafType.STRING}
+
+
+def test_dotnet_conf_lines_without_equals_are_ignored():
+    raw = """\
+## Just a comment with no equals sign
+# Oidc__Audience = topomojo-api
+"""
+    result = flatten_dotnet_conf(raw)
+    assert result == {"Oidc__Audience": LeafType.STRING}

--- a/actions/update-helm-chart/tests/test_runner.py
+++ b/actions/update-helm-chart/tests/test_runner.py
@@ -111,6 +111,69 @@ def test_missing_new_file_raises(tmp_path: Path, monkeypatch):
         )
 
 
+def test_dotnet_conf_end_to_end_diffs_added_and_removed_keys(
+    tmp_path: Path, monkeypatch
+):
+    app_repo = tmp_path / "app"
+    app_repo.mkdir()
+
+    helm_repo = tmp_path / "helm"
+    child_values = (
+        helm_repo / "charts" / "topomojo" / "charts" / "topomojo-api" / "values.yaml"
+    )
+    parent_values = helm_repo / "charts" / "topomojo" / "values.yaml"
+    _write(child_values, "env:\n  Existing__Key: \"\"\n  Removed__Key: \"\"\n")
+    _write(
+        parent_values,
+        "topomojo-api:\n  env:\n    Existing__Key: \"\"\n    Removed__Key: \"\"\n",
+    )
+
+    prev_conf = (
+        "# Existing__Key =\n"
+        "# Removed__Key =\n"
+    )
+    new_conf = (
+        "####################\n"
+        "## AppSettings\n"
+        "####################\n"
+        "# Existing__Key =\n"
+        "# New__Key = topomojo-api\n"
+        "# New__Flag = true\n"
+    )
+
+    fake = _FakeGit(
+        tags=["v3.6.0", "v3.5.0"],
+        files={
+            ("v3.5.0", "src/TopoMojo.Api/appsettings.conf"): prev_conf,
+            ("v3.6.0", "src/TopoMojo.Api/appsettings.conf"): new_conf,
+        },
+    )
+    monkeypatch.setattr(runner, "git_io", fake)
+
+    result = runner.run(
+        app_repo_dir=app_repo,
+        helm_repo_dir=helm_repo,
+        settings_file="src/TopoMojo.Api/appsettings.conf",
+        settings_file_kind="dotnet-conf",
+        chart_file="charts/topomojo/charts/topomojo-api/Chart.yaml",
+        parent_chart_file="charts/topomojo/Chart.yaml",
+        release_tag="v3.6.0",
+    )
+
+    assert result.previous_tag == "v3.5.0"
+    assert result.added == {
+        "New__Key": LeafType.STRING,
+        "New__Flag": LeafType.STRING,
+    }
+    assert result.removed == ["Removed__Key"]
+    child_text = child_values.read_text()
+    parent_text = parent_values.read_text()
+    assert "New__Key" in child_text and "New__Flag" in child_text
+    assert "Removed__Key" not in child_text
+    assert "New__Key" in parent_text and "New__Flag" in parent_text
+    assert "Removed__Key" not in parent_text
+
+
 def test_no_previous_tag_treats_prev_as_empty(tmp_path: Path, monkeypatch):
     app_repo = tmp_path / "app"
     app_repo.mkdir()


### PR DESCRIPTION
## Summary

Adds a third `settings_file_kind` value, `dotnet-conf`, to the `update-helm-chart` action so apps that ship an INI-style `appsettings.conf` (TopoMojo, Gameboard) can participate in settings-sync alongside apps that use JSON `appsettings.json`.

Previously only `dotnet-appsettings` (JSONC) and `angular-settings` (JSON) were accepted; feeding `appsettings.conf` text into either would fail at the JSON parse step. The new kind reads the `.conf` format directly and emits the same `Section__Key` flat-key shape, so the existing dotnet patcher (`env:` block in the child chart's `values.yaml`, mirrored under the parent chart subkey) is reused unchanged.