### PR TITLE
Use github_app_client_id in update-helm-chart action

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ The action:
 | Name | Required | Description |
 | --- | --- | --- |
 | `app_name` | ✅ | Friendly application name used for commit and PR title, e.g. `TopoMojo API`. |
-| `github_app_id` | ✅ | Optional GitHub App ID that should mint a token for pushing to the Helm repo. Provide via a secret. |
-| `github_app_private_key` | ✅ | Private key for the GitHub App. Provide via a secret. |
+| `github_app_client_id` |  | GitHub App client ID that should mint a token for pushing to the Helm repo. Provide via a secret. Preferred over `github_app_id`. |
+| `github_app_id` |  | **Deprecated** — use `github_app_client_id`. GitHub App ID that should mint a token for pushing to the Helm repo. |
+| `github_app_private_key` |  | Private key for the GitHub App. Provide via a secret. Required when either `github_app_client_id` or `github_app_id` is set. |
 | `chart_file` | ✅ | Path to the application's `Chart.yaml` within the Helm repo, e.g. `charts/topomojo/charts/topomojo-api/Chart.yaml`. |
 | `release_tag` |  | Tag from the calling workflow (defaults to `${{ github.event.release.tag_name }}`). |
 | `parent_chart_file` |  | Optional path to a parent `Chart.yaml` that should be bumped. |
@@ -95,7 +96,7 @@ jobs:
         uses: cmu-sei/Crucible-Github-Actions/actions/update-helm-chart@main
         with:
           app_name: TopoMojo API
-          github_app_id: ${{ secrets.CRUCIBLE_HELM_UPDATE_APP_ID }}
+          github_app_client_id: ${{ secrets.CRUCIBLE_HELM_UPDATE_CLIENT_ID }}
           github_app_private_key: ${{ secrets.CRUCIBLE_HELM_UPDATE_PRIVATE_KEY }}
           chart_file: charts/topomojo/charts/topomojo-api/Chart.yaml
           parent_chart_file: charts/topomojo/Chart.yaml
@@ -104,7 +105,7 @@ jobs:
 ### Repository Configuration Checklist
 
 1. **Create credentials** for pushing to `cmu-sei/helm-charts`.
-   - Preferred: register a GitHub App with `contents:write` and `pull_request:write`, install it on `cmu-sei/helm-charts`, and store the app ID and private key as repository secrets (e.g., `CRUCIBLE_HELM_UPDATE_APP_ID`/`CRUCIBLE_HELM_UPDATE_PRIVATE_KEY`).
+   - Preferred: register a GitHub App with `contents:write` and `pull_request:write`, install it on `cmu-sei/helm-charts`, and store the app client ID and private key as repository secrets (e.g., `CRUCIBLE_HELM_UPDATE_CLIENT_ID`/`CRUCIBLE_HELM_UPDATE_PRIVATE_KEY`). The legacy app-ID secret (`CRUCIBLE_HELM_UPDATE_APP_ID`) and `github_app_id` input are deprecated.
    - Alternative: use a fine-grained PAT limited to the Helm charts repo and store as `HELM_CHARTS_TOKEN`; pass it via the optional `helm_repo_token` input.
 2. **Add the workflow** (example above) to the application repository.
    - Trigger on `release` with `types: [published]`.

--- a/actions/update-helm-chart/action.yaml
+++ b/actions/update-helm-chart/action.yaml
@@ -6,12 +6,18 @@ inputs:
   app_name:
     description: "Display name of the application (used in PR title and commit message)."
     required: true
+  github_app_client_id:
+    description: "GitHub App client ID used to mint a token for the Helm repo."
+    required: false
+    default: ""
   github_app_id:
-    description: "GitHub App ID used to mint a token for the Helm repo."
-    required: true
+    description: "Deprecated: GitHub App ID used to mint a token for the Helm repo. Use github_app_client_id instead."
+    required: false
+    default: ""
   github_app_private_key:
     description: "Private key for the GitHub App when minting a token."
-    required: true
+    required: false
+    default: ""
   chart_file:
     description: "Path (within the helm-charts repo) to the Chart.yaml for the application."
     required: true
@@ -102,13 +108,20 @@ runs:
         echo "owner=$owner" >> "$GITHUB_OUTPUT"
         echo "name=$name" >> "$GITHUB_OUTPUT"
 
+    - name: Warn on deprecated github_app_id input
+      if: inputs.github_app_id != ''
+      shell: bash
+      run: |
+        echo "::warning::The 'github_app_id' input is deprecated. Migrate to 'github_app_client_id' (see https://github.com/actions/create-github-app-token/releases/tag/v3.1.0)."
+
     - name: Mint Helm charts app token
       id: mint_token
       if: >
-        (inputs.github_app_id != '') &&
+        ((inputs.github_app_client_id != '') || (inputs.github_app_id != '')) &&
         (inputs.github_app_private_key != '')
       uses: actions/create-github-app-token@v3
       with:
+        client-id: ${{ inputs.github_app_client_id }}
         app-id: ${{ inputs.github_app_id }}
         private-key: ${{ inputs.github_app_private_key }}
         owner: ${{ steps.repo_meta.outputs.owner }}


### PR DESCRIPTION
GitHub prefers using `client-id` over `app-id` as of: https://github.com/actions/create-github-app-token/releases/tag/v3.1.0