### PR TITLE
Add .headerignore exemption support to header action

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ jobs:
 
 The action checks out the current branch, runs `header.py` to add missing headers, and automatically commits/pushes fixes when changes are detected.
 
+#### Exempting files with `.headerignore`
+
+Some files should never receive the Crucible header — for example, vendored sources or files managed by external tooling that carry their own upstream license. To exempt them, add a `.headerignore` file at the root of the calling repository. It uses gitignore-style syntax:
+
+- One pattern per line; blank lines and lines starting with `#` are ignored.
+- Glob patterns are matched against each file's repo-relative, forward-slash path (e.g. `*.md`, `vendor/**`).
+- A directory pattern (a bare directory name or one with a trailing slash, e.g. `.agents/`) exempts everything beneath it.
+
+```gitignore
+# .headerignore — files managed by external tooling; do not add SEI headers.
+.agents/
+.claude/
+```
+
+Matched files are logged as `skipping (ignored): <path>` and left untouched. When no `.headerignore` file is present, every supported file is checked as before.
+
 ## Reusable Workflows
 
 ### Build & Publish Image

--- a/actions/header/action.yaml
+++ b/actions/header/action.yaml
@@ -1,6 +1,6 @@
 name: Header Check
 
-description: "Ensures that all files have a license header"
+description: "Ensures that all files have a license header. Paths matched by a .headerignore file in the repo root are exempted."
 
 inputs:
   github_token:

--- a/actions/header/header.py
+++ b/actions/header/header.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 import sys
+import fnmatch
 
 header_test = 'Released under a MIT (SEI)-style license'
 header = 'Copyright ' + str(datetime.date.today().year) + ' Carnegie Mellon University. All Rights Reserved.\nReleased under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.'
@@ -10,12 +11,60 @@ use_block_comments = False
 if len(sys.argv) > 1:
     use_block_comments = sys.argv[1].lower() == 'true'
 
+
+def load_ignore_patterns(path='.headerignore'):
+    # Read gitignore-style exemption patterns from a .headerignore file in the
+    # repo root. Missing file means no exemptions (original behavior).
+    patterns = []
+    if not os.path.isfile(path):
+        return patterns
+    with open(path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            # skip blank lines and comments
+            if not line or line.startswith('#'):
+                continue
+            patterns.append(line)
+    return patterns
+
+
+def is_ignored(rel_path, patterns):
+    # Match a repo-relative path (forward-slash separated, no leading ./)
+    # against the ignore patterns. Supports:
+    #   - glob patterns (fnmatch), e.g. "*.md", ".agents/**"
+    #   - directory prefixes, e.g. ".agents/" or ".agents" exempt the whole tree
+    for pattern in patterns:
+        # directory-prefix patterns: a trailing slash, or a bare dir name,
+        # exempts everything beneath it
+        dir_prefix = pattern.rstrip('/')
+        if rel_path == dir_prefix or rel_path.startswith(dir_prefix + '/'):
+            return True
+        # glob match against the full relative path
+        if fnmatch.fnmatch(rel_path, pattern):
+            return True
+        # support "**" recursive globs, which fnmatch doesn't expand by default
+        if '**' in pattern and fnmatch.fnmatch(rel_path, pattern.replace('**', '*')):
+            return True
+    return False
+
+
+ignore_patterns = load_ignore_patterns()
+if ignore_patterns:
+    print('header ignore patterns:')
+    for pattern in ignore_patterns:
+        print('  ' + pattern)
+
 print('header not in:')
-# iterate over all files in directory 
+# iterate over all files in directory
 for root, dirs, files in os.walk("."):
     for file in files:
         # only care about files with extensions considered to be source code
         if file.endswith(('.cs', '.ts', '.js', '.css', '.php', '.xml', '.html', '.scss', '.py', '.go')):
+            # normalize to a repo-relative, forward-slash path and skip exemptions
+            rel_path = os.path.relpath(os.path.join(root, file), '.').replace(os.sep, '/')
+            if is_ignored(rel_path, ignore_patterns):
+                print('skipping (ignored): ' + rel_path)
+                continue
             # open file & read it
             with open(os.path.join(root,file), 'r') as original: data = original.read()
             # check file for header


### PR DESCRIPTION
The header action walked every source file and prepended the SEI license header with no way to exclude files. Vendored sources and files managed by external tooling (which carry their own upstream licenses) were being modified incorrectly.

Add support for a gitignore-style .headerignore file at the calling repo root: glob patterns and directory prefixes matched against each file's repo-relative path are skipped. With no .headerignore present, behavior is unchanged.